### PR TITLE
Connect from the Dashboard with one click

### DIFF
--- a/src/main/kotlin/com/github/devspaces/gateway/DevSpacesConnectionProvider.kt
+++ b/src/main/kotlin/com/github/devspaces/gateway/DevSpacesConnectionProvider.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2024 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package com.github.devspaces.gateway
+
+import com.jetbrains.gateway.api.ConnectionRequestor
+import com.jetbrains.gateway.api.GatewayConnectionHandle
+import com.jetbrains.gateway.api.GatewayConnectionProvider
+import com.jetbrains.gateway.thinClientLink.LinkedClientManager
+import com.jetbrains.rd.util.lifetime.Lifetime
+import java.net.URI
+
+/**
+ * Handles links as:
+ *      jetbrains-gateway://connect#type=devspaces
+ *      https://code-with-me.jetbrains.com/remoteDev#type=devspaces
+ */
+class DevSpacesConnectionProvider : GatewayConnectionProvider {
+
+    override suspend fun connect(parameters: Map<String, String>, requestor: ConnectionRequestor): GatewayConnectionHandle? {
+        val joinLink = parameters["link"]?.replace("_", "&")
+        LinkedClientManager.getInstance().startNewClient(Lifetime.Eternal, URI(joinLink))
+        return null
+    }
+
+    override fun isApplicable(parameters: Map<String, String>): Boolean {
+        return parameters["type"] == "devspaces"
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <!-- Plugin Configuration File. Read more: https://plugins.jetbrains.com/docs/intellij/plugin-configuration-file.html -->
 <idea-plugin>
     <id>com.github.devspaces.gateway</id>
-    <name>OpenShift DevSpaces</name>
+    <name>OpenShift Dev Spaces</name>
     <vendor>Red Hat</vendor>
 
     <depends>com.intellij.modules.platform</depends>
@@ -10,6 +10,6 @@
 
     <extensions defaultExtensionNs="com.jetbrains">
         <gatewayConnector implementation="com.github.devspaces.gateway.DevSpacesConnector"/>
-<!--        <gatewayConnectionProvider implementation="com.github.devspaces.gateway.DevSpacesConnectionProvider"/>-->
+        <gatewayConnectionProvider implementation="com.github.devspaces.gateway.DevSpacesConnectionProvider"/>
     </extensions>
 </idea-plugin>


### PR DESCRIPTION
The commit https://github.com/che-incubator/che-idea-dev-server/commit/e0efaeb4b312c542fcf091bf01c3b8d39442ef13 adds:
- running the local Gateway application immediately after starting a Workspace
- passing the IDEA connection link to our Gateway plugin

This PR makes it possible to connect JB ThinClient to a running Workspace automatically when the user clicks the browser's pop-up:
<img width="809" alt="image" src="https://github.com/redhat-developer/devspaces-gateway-plugin/assets/1636395/e71fe083-852b-4212-aa26-95c21d433b30">


https://github.com/redhat-developer/devspaces-gateway-plugin/assets/1636395/0663a332-927d-41c3-afd7-70ad58aac057

It still requires enabling port-forwarding manually, in the terminal. I'm going to automate it in the next PR.
