### PR TITLE
Connect to a running DevWorkspace with the JetBrains Client from the Dashboard

### DIFF
--- a/src/main/kotlin/com/github/devspaces/gateway/DevSpacesConnection.kt
+++ b/src/main/kotlin/com/github/devspaces/gateway/DevSpacesConnection.kt
@@ -14,8 +14,8 @@ package com.github.devspaces.gateway
 import com.github.devspaces.gateway.openshift.Pods
 import com.github.devspaces.gateway.openshift.Utils
 import com.jetbrains.gateway.thinClientLink.LinkedClientManager
+import com.jetbrains.gateway.thinClientLink.ThinClientHandle
 import com.jetbrains.rd.util.lifetime.Lifetime
-import com.jetbrains.rd.util.lifetime.waitTermination
 import io.kubernetes.client.openapi.models.V1Pod
 import java.io.Closeable
 import java.io.IOException
@@ -24,7 +24,7 @@ import java.net.URI
 class DevSpacesConnection(private val devSpacesContext: DevSpacesContext) {
     @Throws(Exception::class)
     @Suppress("UnstableApiUsage")
-    fun connect(onStarted: () -> Unit, onTerminated: () -> Unit) {
+    fun connect(onStarted: () -> Unit, onTerminated: () -> Unit): ThinClientHandle {
         val dwName = Utils.getValue(devSpacesContext.devWorkspace, arrayOf("metadata", "name")) as String
         val dwNamespace = Utils.getValue(devSpacesContext.devWorkspace, arrayOf("metadata", "namespace")) as String
 
@@ -61,6 +61,7 @@ class DevSpacesConnection(private val devSpacesContext: DevSpacesContext) {
                 }
             )
         }
+        return client;
     }
 
     private fun getConnectionLink(pod: V1Pod): String {

--- a/src/main/kotlin/com/github/devspaces/gateway/DevSpacesConnectionHandle.kt
+++ b/src/main/kotlin/com/github/devspaces/gateway/DevSpacesConnectionHandle.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2024 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package com.github.devspaces.gateway
+
+import com.jetbrains.gateway.api.CustomConnectionFrameComponentProvider
+import com.jetbrains.gateway.api.CustomConnectionFrameContext
+import com.jetbrains.gateway.api.GatewayConnectionHandle
+import com.jetbrains.gateway.thinClientLink.ThinClientHandle
+import com.jetbrains.rd.util.lifetime.Lifetime
+import javax.swing.JComponent
+
+class DevSpacesConnectionHandle(
+    lifetime: Lifetime,
+    clientHandle: ThinClientHandle,
+    private val connectionFrameComponent: JComponent,
+    private val wsName: String
+) : GatewayConnectionHandle(lifetime, clientHandle) {
+    override fun customComponentProvider(lifetime: Lifetime) = object : CustomConnectionFrameComponentProvider {
+        override val closeConfirmationText = "Disconnect from DevWorkspace ${wsName}?"
+        override fun createComponent(context: CustomConnectionFrameContext) = connectionFrameComponent
+    }
+
+    override fun getTitle(): String {
+        return "DevWorkspace $wsName"
+    }
+
+    override fun hideToTrayOnStart(): Boolean {
+        return true
+    }
+}

--- a/src/main/kotlin/com/github/devspaces/gateway/openshift/OpenShiftClientFactory.kt
+++ b/src/main/kotlin/com/github/devspaces/gateway/openshift/OpenShiftClientFactory.kt
@@ -12,20 +12,25 @@
 package com.github.devspaces.gateway.openshift
 
 import io.kubernetes.client.openapi.ApiClient
+import io.kubernetes.client.util.ClientBuilder
 import io.kubernetes.client.util.Config
 import io.kubernetes.client.util.KubeConfig
 
-class OpenShiftClientFactory(private val host: String, private val port: String, private val token: CharArray) {
+class OpenShiftClientFactory() {
     private val userName = "openshift_user"
     private val contextName = "openshift_context"
     private val clusterName = "openshift_cluster"
 
     fun create(): ApiClient {
-        val kubeConfig = createKubeConfig()
+        return ClientBuilder.defaultClient()
+    }
+
+    fun create(host: String, port: String, token: CharArray): ApiClient {
+        val kubeConfig = createKubeConfig(host, port, token)
         return Config.fromConfig(kubeConfig)
     }
 
-    private fun createKubeConfig(): KubeConfig {
+    private fun createKubeConfig(host: String, port: String, token: CharArray): KubeConfig {
         val cluster = mapOf(
             "name" to clusterName,
             "cluster" to mapOf(

--- a/src/main/kotlin/com/github/devspaces/gateway/view/steps/DevSpacesOpenShiftConnectionStepView.kt
+++ b/src/main/kotlin/com/github/devspaces/gateway/view/steps/DevSpacesOpenShiftConnectionStepView.kt
@@ -25,7 +25,7 @@ import com.intellij.util.ui.JBFont
 import com.intellij.util.ui.JBUI
 
 class DevSpacesOpenShiftConnectionStepView(private var devSpacesContext: DevSpacesContext) : DevSpacesWizardStep {
-    private var tfHost = JBTextField()
+    private var tfHost = JBTextField("api.che-dev.x6e0.p1.openshiftapps.com")
     private var tfPort = JBTextField("6443")
     private var tfPassword = JBPasswordField()
 
@@ -65,7 +65,8 @@ class DevSpacesOpenShiftConnectionStepView(private var devSpacesContext: DevSpac
 
     private fun testConnection(): Boolean {
         try {
-            val client = OpenShiftClientFactory(tfHost.text, tfPort.text, tfPassword.password).create()
+//            val client = OpenShiftClientFactory().create(tfHost.text, tfPort.text, tfPassword.password)
+            val client = OpenShiftClientFactory().create(tfHost.text, tfPort.text, "sha256~JN7ojBE7hfj5xxthkWlmYTEHexIekN-FoYEb8K4eY_s".toCharArray())
             devSpacesContext.client = client
 
             Projects(client).list()


### PR DESCRIPTION
https://issues.redhat.com/browse/CRW-5677

This PR complements my previous one https://github.com/redhat-developer/devspaces-gateway-plugin/pull/19 with the following:
- login information from the local `.kube/config` is used, so the user doesn't need to care about it on each Gateway start
- port-forwarding is enabled automatically using the code from the PR https://github.com/redhat-developer/devspaces-gateway-plugin/pull/16/files
- system tray icon is added for quick disconnect and adding more commands in future

![Screen Recording 2024-02-21 at 15 34 46](https://github.com/redhat-developer/devspaces-gateway-plugin/assets/1636395/b7e7b637-2e8c-441d-b222-0256c1f1e299)
