### PR TITLE
Retrieve connection link for a correct project folder

### DIFF
--- a/src/main/kotlin/com/github/devspaces/gateway/DevSpacesConnection.kt
+++ b/src/main/kotlin/com/github/devspaces/gateway/DevSpacesConnection.kt
@@ -81,7 +81,7 @@ class DevSpacesConnection(private val devSpacesContext: DevSpacesContext) {
         for (i in 1..12) {
             val result = Pods(devSpacesContext.client).exec(
                 pod,
-                arrayOf("/bin/sh", "-c", "/idea-server/bin/remote-dev-server.sh status \$PROJECTS_ROOT | grep -Eo -m1 'tcp://[^\"]+'"),
+                arrayOf("/bin/sh", "-c", "/idea-server/bin/remote-dev-server.sh status \$PROJECT_SOURCE | grep -Eo -m1 'tcp://[^\"]+'"),
                 container.name
             ).trim()
             if (result.startsWith("tcp://")) return result


### PR DESCRIPTION
Get the connection link for the `$PROJECT_SOURCE` folder as [it's served by the IDE server](https://github.com/che-incubator/che-idea-dev-server/blob/1a2f026ae3580e1be6001cc8e5b67b726f1b2673/build/dockerfiles/entrypoint-volume.sh#L35).

See the difference in the command output for different folders:
- ` ./remote-dev-server.sh status $PROJECTS_ROOT`
```
STATUS:
{
  "appPid": 1298,
  "appVersion": "IU-232.10227.8",
  "runtimeVersion": "17.0.9b1000.46",
  "unattendedMode": false,
  "backendUnresponsive": false,
  "modalDialogIsOpened": false,
  "idePath": "/idea-server"
}
```
- ` ./remote-dev-server.sh status $PROJECT_SOURCE`
```
STATUS:
{
  "appPid": 248,
  "appVersion": "IU-232.10227.8",
  "runtimeVersion": "17.0.9b1000.46",
  "unattendedMode": true,
  "backendUnresponsive": false,
  "modalDialogIsOpened": false,
  "idePath": "/idea-server",
  "joinLink": "tcp://127.0.0.1:5990#jt=658942dc-c1e7-4a2a-a6e9-c80bb8872f74&p=IU&fp=43DDD406334354436D9B24815CCD656CCD6816B80B94C7EA8B0EF994DE4C6211&cb=232.10227.8&newUi=true&jb=17.0.9b1000.46",
  "httpLink": "https://code-with-me.jetbrains.com/remoteDev#idePath=%2Fidea-server&projectPath=%2Fprojects%2Fnodejs-react-redux&host=workspacec65ec93f28df474b-6489458896-h4mst&port=22&user=user&type=ssh&deploy=false&newUi=true",
  "gatewayLink": "jetbrains-gateway://connect#idePath=%2Fidea-server&projectPath=%2Fprojects%2Fnodejs-react-redux&host=workspacec65ec93f28df474b-6489458896-h4mst&port=22&user=user&type=ssh&deploy=false&newUi=true",
  "projects": [
    {
      "projectName": "nodejs-react-redux",
      "projectPath": "/projects/nodejs-react-redux",
      "joinLink": "tcp://127.0.0.1:5990#jt=658942dc-c1e7-4a2a-a6e9-c80bb8872f74&p=IU&fp=43DDD406334354436D9B24815CCD656CCD6816B80B94C7EA8B0EF994DE4C6211&cb=232.10227.8&newUi=true&jb=17.0.9b1000.46",
      "httpLink": "https://code-with-me.jetbrains.com/remoteDev#idePath=%2Fidea-server&projectPath=%2Fprojects%2Fnodejs-react-redux&host=workspacec65ec93f28df474b-6489458896-h4mst&port=22&user=user&type=ssh&deploy=false&newUi=true",
      "gatewayLink": "jetbrains-gateway://connect#idePath=%2Fidea-server&projectPath=%2Fprojects%2Fnodejs-react-redux&host=workspacec65ec93f28df474b-6489458896-h4mst&port=22&user=user&type=ssh&deploy=false&newUi=true",
      "controllerConnected": false,
      "secondsSinceLastControllerActivity": 117774,
      "backgroundTasksRunning": false,
      "users": [
        "user"
      ]
    }
  ]
}
```
