### PR TITLE
Fix the `Build / Verify plugin (push)` PR status check

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,12 +7,12 @@ pluginRepositoryUrl = https://github.com/redhat-developer/devspaces-gateway-plug
 pluginVersion = 0.0.1
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
-pluginSinceBuild = 223
-pluginUntilBuild = 233.*
+pluginSinceBuild = 241
+pluginUntilBuild = 241.*
 
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#configuration-intellij-extension
 platformType = GW
-platformVersion = 233.14015.42-CUSTOM-SNAPSHOT
+platformVersion = 241.13688-EAP-CANDIDATE-SNAPSHOT
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22

--- a/src/main/kotlin/com/github/devspaces/gateway/DevSpacesConnectionHandle.kt
+++ b/src/main/kotlin/com/github/devspaces/gateway/DevSpacesConnectionHandle.kt
@@ -18,6 +18,7 @@ import com.jetbrains.gateway.thinClientLink.ThinClientHandle
 import com.jetbrains.rd.util.lifetime.Lifetime
 import javax.swing.JComponent
 
+@Suppress("UnstableApiUsage")
 class DevSpacesConnectionHandle(
     lifetime: Lifetime,
     clientHandle: ThinClientHandle,

--- a/src/main/kotlin/com/github/devspaces/gateway/DevSpacesConnectionProvider.kt
+++ b/src/main/kotlin/com/github/devspaces/gateway/DevSpacesConnectionProvider.kt
@@ -32,7 +32,6 @@ private const val DW_NAME = "dwName"
  */
 class DevSpacesConnectionProvider : GatewayConnectionProvider {
 
-    @Suppress("UnstableApiUsage")
     override suspend fun connect(parameters: Map<String, String>, requestor: ConnectionRequestor): GatewayConnectionHandle? {
         thisLogger().debug("Launched Dev Spaces connection provider", parameters)
 
@@ -76,7 +75,7 @@ class DevSpacesConnectionProvider : GatewayConnectionProvider {
             }
         }
 
-        return DevSpacesConnectionHandle(Lifetime.Eternal.createNested(), thinClient, connectionFrameComponent, dwName!!)
+        return DevSpacesConnectionHandle(Lifetime.Eternal.createNested(), thinClient, connectionFrameComponent, dwName)
     }
 
     override fun isApplicable(parameters: Map<String, String>): Boolean {


### PR DESCRIPTION
Fixes the `Build / Verify plugin (push)` PR status check to unblock the `Build / Release draft (push)` job.

```
Compatibility problems (1): 
    #Invocation of unresolved constructor com.jetbrains.gateway.api.GatewayConnectionHandle.<init>(Lifetime, ThinClientHandle)
        Constructor com.github.devspaces.gateway.DevSpacesConnectionHandle.<init>(com.jetbrains.rd.util.lifetime.Lifetime lifetime, com.jetbrains.gateway.thinClientLink.ThinClientHandle clientHandle, javax.swing.JComponent connectionFrameComponent, java.lang.String wsName) contains an *invokespecial* instruction referencing an unresolved constructor com.jetbrains.gateway.api.GatewayConnectionHandle.<init>(com.jetbrains.rd.util.lifetime.Lifetime, com.jetbrains.gateway.thinClientLink.ThinClientHandle). This can lead to **NoSuchMethodError** exception at runtime.
```
