### PR TITLE
Set unlimited 'Until Build' setting

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ pluginVersion = 0.0.9
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 241
-pluginUntilBuild = 243.*
+pluginUntilBuild = *
 
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#configuration-intellij-extension
 platformType = GW

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ pluginVersion = 0.0.9
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 241
-pluginUntilBuild = *
+pluginUntilBuild = *.*
 
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#configuration-intellij-extension
 platformType = GW

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,12 +8,12 @@ pluginVersion = 0.0.9
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 241
-pluginUntilBuild = *.*
+pluginUntilBuild = 251.*
 
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#configuration-intellij-extension
 platformType = GW
 #https://www.jetbrains.com/updates/updates.xml
-platformVersion = 2024.3.3
+platformVersion = 2025.1
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.jetbrains.php:203.4449.22, org.intellij.scala:2023.3.27@EAP


### PR DESCRIPTION
This is not to release a new version each time JetBrains releases a version of the platform.
In 99% of the cases, it doesn't require more changes than just bumping up the `pluginUntilBuild` setting.

<img width="668" alt="image" src="https://github.com/user-attachments/assets/2a7ac28e-db7c-491f-92f1-a38e56400c67" />
