### PR TITLE
Support the UBI9-based user containers

### DIFF
--- a/src/main/kotlin/com/redhat/devtools/gateway/server/RemoteServer.kt
+++ b/src/main/kotlin/com/redhat/devtools/gateway/server/RemoteServer.kt
@@ -42,6 +42,12 @@ class RemoteServer(private val devSpacesContext: DevSpacesContext) {
             .exec(
                 pod,
                 arrayOf(
+//                  remote-dev-server.sh writes to several sub-folders of HOME (.config, .cache, etc.)
+//                  When registry.access.redhat.com/ubi9 is used for running a user container,
+//                  HOME=/ which is read-only.
+//                  In this case, we point remote-dev-server.sh to a writable HOME.
+                    "env",
+                    "HOME=/tmp/user",
                     "/bin/sh",
                     "-c",
                     "/idea-server/bin/remote-dev-server.sh status \$PROJECT_SOURCE | awk '/STATUS:/{p=1; next} p'"


### PR DESCRIPTION
This is part of the fix for supporting the user containers based on the registry.access.redhat.com/ubi9.
https://issues.redhat.com/browse/CRW-8294

When connecting to a remote CDE, the plugin executes a remote command (`remote-dev-server.sh status`) in a user container to check the state of the headless IDE server. The command writes to several sub-folders of HOME (.config, .cache, etc.)
In case of `registry.access.redhat.com/ubi9`, `HOME=/`, which is read-only.
To allow such commands to be run, we set `HOME` for the running command to a writable location.
