### PR TITLE
Declare compatibility against GW 2025.2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ pluginVersion = 0.0.9
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 251
-pluginUntilBuild = 251.*
+pluginUntilBuild = 252.*
 
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#configuration-intellij-extension
 platformType = GW


### PR DESCRIPTION
Each time a new Gateway release (major or minor version) is out, the current version of this plugin becomes incompatible with the latest Gateway. In such a case, we need to release a new plugin version with a declaration of supporting the latest Gateway, by bumping up `pluginUntilBuild`. Between a new Gateway version is released and a new version of the plugin being approved on JetBrains Marketplace, the user should wait for a few days.

This PR attempts to solve this problem. So, the latest version of this plugin should already support the next Gateway version, which is going to be released after the latest one.

IntelliJ Plugin Verifier shows that the plugin is compatible with 2025.2 eap:

<img width="1155" alt="image" src="https://github.com/user-attachments/assets/5d29c073-d933-4076-870e-2ea8ca76c3da" />


This is more like an experiment. If such an approach works as expected, we will probably apply it permanently, for every plugin version.
