### PR TITLE
Jetbrains Gateway wont tell me that my token is outdated #23487

### DIFF
--- a/src/main/kotlin/com/redhat/devtools/gateway/DevSpacesConnectionProvider.kt
+++ b/src/main/kotlin/com/redhat/devtools/gateway/DevSpacesConnectionProvider.kt
@@ -21,6 +21,8 @@ import com.jetbrains.gateway.api.GatewayConnectionProvider
 import com.redhat.devtools.gateway.openshift.DevWorkspaces
 import com.redhat.devtools.gateway.openshift.OpenShiftClientFactory
 import com.redhat.devtools.gateway.openshift.kube.KubeConfigBuilder
+import com.redhat.devtools.gateway.openshift.kube.isNotFound
+import com.redhat.devtools.gateway.openshift.kube.isUnauthorized
 import io.kubernetes.client.openapi.ApiException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -99,7 +101,7 @@ class DevSpacesConnectionProvider : GatewayConnectionProvider {
     }
 
     private suspend fun handleUnauthorizedError(err: ApiException): Boolean {
-        if (err.code != 401) return false
+        if (!err.isUnauthorized()) return false
 
         val tokenNote = if (KubeConfigBuilder.isTokenAuthUsed())
             "\n\nYou are using token-based authentication.\nUpdate your token in the kubeconfig file."
@@ -115,7 +117,7 @@ class DevSpacesConnectionProvider : GatewayConnectionProvider {
     }
 
     private suspend fun handleNotFoundError(err: ApiException): Boolean {
-        if (err.code != 404) return false
+        if (!err.isNotFound()) return false
 
         val message = """
             Workspace or DevWorkspace support not found.

--- a/src/main/kotlin/com/redhat/devtools/gateway/openshift/kube/ApiExceptionUtils.kt
+++ b/src/main/kotlin/com/redhat/devtools/gateway/openshift/kube/ApiExceptionUtils.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2025 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package com.redhat.devtools.gateway.openshift.kube
+
+import io.kubernetes.client.openapi.ApiException
+
+fun ApiException.isNotFound(): Boolean {
+    return code == 404
+}
+
+fun ApiException.isUnauthorized(): Boolean {
+    return code == 401
+}


### PR DESCRIPTION
The handlers were added for 401-Unauthorized and 404-NotFound errors when connecting to DevWorkspaces. The valuable error messages displayed instead of the default one.

An error message for an expired or wrong authentication token used:

<img width="463" height="236" alt="Screenshot From 2025-07-22 03-57-45" src="https://github.com/user-attachments/assets/199b29fc-4dde-4871-ac81-6148413d7b5e" />

An error message for an attempt to connect to a cluster/namespace that has no DevWorkspace installed: 

<img width="463" height="236" alt="Screenshot From 2025-07-22 03-56-58" src="https://github.com/user-attachments/assets/7e2d1ad0-dd29-46de-8e81-29feb7627d8e" />


Fixes https://github.com/eclipse-che/che/issues/23487