### PR TITLE
Jetbrains Gateway cannot connect after 3.5h IDLE period

### DIFF
--- a/src/main/kotlin/com/redhat/devtools/gateway/DevSpacesConnection.kt
+++ b/src/main/kotlin/com/redhat/devtools/gateway/DevSpacesConnection.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Red Hat, Inc.
+ * Copyright (c) 2024-2025 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -11,81 +11,178 @@
  */
 package com.redhat.devtools.gateway
 
-import com.redhat.devtools.gateway.openshift.DevWorkspaces
-import com.redhat.devtools.gateway.openshift.Pods
-import com.redhat.devtools.gateway.server.RemoteIDEServer
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.diagnostic.thisLogger
+import com.intellij.openapi.ui.Messages
 import com.jetbrains.gateway.thinClientLink.LinkedClientManager
 import com.jetbrains.gateway.thinClientLink.ThinClientHandle
 import com.jetbrains.rd.util.lifetime.Lifetime
+import com.redhat.devtools.gateway.openshift.DevWorkspaces
+import com.redhat.devtools.gateway.openshift.Pods
+import com.redhat.devtools.gateway.server.RemoteIDEServer
+import com.redhat.devtools.gateway.server.RemoteIDEServerStatus
 import io.kubernetes.client.openapi.ApiException
+import okio.Closeable
 import java.io.IOException
 import java.net.URI
+import java.util.concurrent.CancellationException
+import java.util.concurrent.atomic.AtomicInteger
 
 class DevSpacesConnection(private val devSpacesContext: DevSpacesContext) {
-    @Throws(Exception::class)
+    @Throws(Exception::class, CancellationException::class)
     @Suppress("UnstableApiUsage")
     fun connect(
         onConnected: () -> Unit,
         onDisconnected: () -> Unit,
         onDevWorkspaceStopped: () -> Unit,
+        onProgress: ((message: String) -> Unit)? = null,
+        isCancelled: (() -> Boolean)? = null
     ): ThinClientHandle {
         if (devSpacesContext.isConnected)
             throw IOException(String.format("Already connected to %s", devSpacesContext.devWorkspace.metadata.name))
 
         devSpacesContext.isConnected = true
         try {
-            return doConnection(onConnected, onDevWorkspaceStopped, onDisconnected)
+            return doConnection(onConnected, onDevWorkspaceStopped, onDisconnected, onProgress, isCancelled)
         } catch (e: Exception) {
             devSpacesContext.isConnected = false
             throw e
         }
     }
 
-    @Throws(Exception::class)
+    @Throws(Exception::class, CancellationException::class)
     @Suppress("UnstableApiUsage")
     private fun doConnection(
         onConnected: () -> Unit,
         onDevWorkspaceStopped: () -> Unit,
-        onDisconnected: () -> Unit
+        onDisconnected: () -> Unit,
+        onProgress: ((message: String) -> Unit)? = null,
+        isCancelled: (() -> Boolean)? = null
     ): ThinClientHandle {
-        startAndWaitDevWorkspace()
+        startAndWaitDevWorkspace(onProgress)
+        if (isCancelled?.invoke() == true) {
+            throw CancellationException("User cancelled the operation")
+        }
 
-        val remoteIdeServer = RemoteIDEServer(devSpacesContext)
-        val remoteIdeServerStatus = remoteIdeServer.getStatus()
+        onProgress?.invoke("Waiting for the Remote IDE server to get ready...")
+        val (remoteIdeServer, remoteIdeServerStatus) =
+            try {
+                val remoteIdeServer = RemoteIDEServer(devSpacesContext).apply {
+                    waitRemoteIDEServerReady()
+                }
+                remoteIdeServer to remoteIdeServer.getStatus()
+            } catch (_: IOException) {
+                null to RemoteIDEServerStatus.empty()
+            }
+
+        if (isCancelled?.invoke() == true) {
+            throw CancellationException("User cancelled the operation")
+        }
+
+        if (remoteIdeServer == null || !remoteIdeServerStatus.isReady) {
+            thisLogger().debug("Remote IDE server is in an invalid state. Please restart the pod and try again. ")
+            val result = AtomicInteger(-1)
+            ApplicationManager.getApplication().invokeAndWait {
+                result.set(
+                    Messages.showDialog(
+                        "The Remote IDE Server is not responding properly.\n" +
+                                "Would you like to try restarting the Pod or cancel the connection?",
+                        "Remote IDE Server Issue",
+                        arrayOf("Cancel Connection", "Restart Pod and try again"),
+                        0,  // default selected index
+                        Messages.getWarningIcon()
+                    )
+                )
+            }
+
+            when (result.get()) {
+                1 -> {
+                    // User chose "Restart Pod"
+                    thisLogger().info("User chose to restart the pod.")
+                    stopAndWaitDevWorkspace(onProgress)
+                    if (isCancelled?.invoke() == true) {
+                        throw CancellationException("User cancelled the operation")
+                    }
+                    return doConnection(onConnected, onDevWorkspaceStopped, onDisconnected, onProgress, isCancelled)
+                }
+            }
+
+            // User chose "Cancel Connection"
+            thisLogger().info("User cancelled the remote IDE connection.")
+            throw IllegalStateException("Remote IDE server is not responding properly. Try restarting the pod and reconnecting.")
+        }
 
         val client = LinkedClientManager
             .getInstance()
             .startNewClient(
                 Lifetime.Eternal,
-                URI(remoteIdeServerStatus.joinLink),
+                URI(remoteIdeServerStatus.joinLink!!),
                 "",
                 onConnected,
                 false
             )
 
         val forwarder = Pods(devSpacesContext.client).forward(remoteIdeServer.pod, 5990, 5990)
-
-        client.run {
-            lifetime.onTermination { forwarder.close() }
-            lifetime.onTermination {
-                if (remoteIdeServer.waitServerTerminated())
-                    DevWorkspaces(devSpacesContext.client)
-                        .stop(
-                            devSpacesContext.devWorkspace.metadata.namespace,
-                            devSpacesContext.devWorkspace.metadata.name
-                        )
-                        .also { onDevWorkspaceStopped() }
+        try {
+            client.run {
+                lifetime.onTermination {
+                    cleanup(forwarder, remoteIdeServer, devSpacesContext, onDevWorkspaceStopped, onDisconnected)
+                }
             }
-            lifetime.onTermination { devSpacesContext.isConnected = false }
-            lifetime.onTermination(onDisconnected)
+        } catch (e: Exception) {
+            cleanup(forwarder, remoteIdeServer, devSpacesContext, onDevWorkspaceStopped, onDisconnected)
+            throw e // rethrow so caller can handle the original problem
         }
 
         return client
     }
 
-    @Throws(IOException::class, ApiException::class)
-    private fun startAndWaitDevWorkspace() {
-        if (!devSpacesContext.devWorkspace.spec.started) {
+    private fun cleanup(
+        forwarder: Closeable?,
+        remoteIdeServer: RemoteIDEServer?,
+        devSpacesContext: DevSpacesContext,
+        onDevWorkspaceStopped: () -> Unit,
+        onDisconnected: () -> Unit
+    ) {
+        try {
+            forwarder?.close()
+            thisLogger().info("Closed port forwarder")
+        } catch (e: Exception) {
+            thisLogger().debug("Failed to close port forwarder", e)
+        }
+
+        try {
+            if (remoteIdeServer?.isRemoteIdeServerState(false) == true) {
+                DevWorkspaces(devSpacesContext.client)
+                    .stop(
+                        devSpacesContext.devWorkspace.metadata.namespace,
+                        devSpacesContext.devWorkspace.metadata.name
+                    )
+                    .also { onDevWorkspaceStopped() }
+            }
+        } catch (e: Exception) {
+            thisLogger().debug("Failed to stop DevWorkspace", e)
+        }
+
+        devSpacesContext.isConnected = false
+
+        try {
+            onDisconnected()
+        } catch (e: Exception) {
+            thisLogger().debug("onDisconnected handler failed", e)
+        }
+    }
+
+
+    @Throws(IOException::class, ApiException::class, CancellationException::class)
+    private fun startAndWaitDevWorkspace(onProgress: ((message: String) -> Unit)? = null,
+                                         isCancelled: (() -> Boolean)? = null) {
+        // We really need a refreshed DevWorkspace here
+        val devWorkspace = DevWorkspaces(devSpacesContext.client).get(
+            devSpacesContext.devWorkspace.metadata.namespace,
+            devSpacesContext.devWorkspace.metadata.name)
+
+        if (!devWorkspace.spec.started) {
             DevWorkspaces(devSpacesContext.client)
                 .start(
                     devSpacesContext.devWorkspace.metadata.namespace,
@@ -94,15 +191,59 @@ class DevSpacesConnection(private val devSpacesContext: DevSpacesContext) {
         }
 
         if (!DevWorkspaces(devSpacesContext.client)
-                .waitPhase(
+                .waitForPhase(
                     devSpacesContext.devWorkspace.metadata.namespace,
                     devSpacesContext.devWorkspace.metadata.name,
                     DevWorkspaces.RUNNING,
-                    DevWorkspaces.RUNNING_TIMEOUT
+                    onProgress = { phase, message ->
+                        onProgress?.invoke(buildString {
+                            append("Phase: $phase")
+                            if (message.isNotBlank()) append(" – $message")
+                        })
+                    },
+                    isCancelled = { isCancelled?.invoke() ?: false }
                 )
         ) throw IOException(
             String.format(
                 "DevWorkspace '%s' is not running after %d seconds",
+                devSpacesContext.devWorkspace.metadata.name,
+                DevWorkspaces.RUNNING_TIMEOUT
+            )
+        )
+    }
+
+    @Throws(IOException::class, ApiException::class, CancellationException::class)
+    private fun stopAndWaitDevWorkspace(onProgress: ((message: String) -> Unit)? = null,
+                                        isCancelled: (() -> Boolean)? = null) {
+        // We really need a refreshed DevWorkspace here
+        val devWorkspace = DevWorkspaces(devSpacesContext.client).get(
+            devSpacesContext.devWorkspace.metadata.namespace,
+            devSpacesContext.devWorkspace.metadata.name)
+
+        if (devWorkspace.spec.started) {
+            DevWorkspaces(devSpacesContext.client)
+                .stop(
+                    devSpacesContext.devWorkspace.metadata.namespace,
+                    devSpacesContext.devWorkspace.metadata.name
+                )
+        }
+
+        if (!DevWorkspaces(devSpacesContext.client)
+                .waitForPhase(
+                    devSpacesContext.devWorkspace.metadata.namespace,
+                    devSpacesContext.devWorkspace.metadata.name,
+                    DevWorkspaces.STOPPED,
+                    onProgress = { phase, message ->
+                        onProgress?.invoke(buildString {
+                            append("Phase: $phase")
+                            if (message.isNotBlank()) append(" – $message")
+                        })
+                    },
+                    isCancelled = { isCancelled?.invoke() ?: false }
+                )
+        ) throw IOException(
+            String.format(
+                "DevWorkspace '%s' is not stopped after %d seconds",
                 devSpacesContext.devWorkspace.metadata.name,
                 DevWorkspaces.RUNNING_TIMEOUT
             )

--- a/src/main/kotlin/com/redhat/devtools/gateway/openshift/DevWorkspace.kt
+++ b/src/main/kotlin/com/redhat/devtools/gateway/openshift/DevWorkspace.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Red Hat, Inc.
+ * Copyright (c) 2024-2025 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -77,14 +77,22 @@ data class DevWorkspaceSpec(
 }
 
 data class DevWorkspaceStatus(
-    val phase: String
+    val phase: String,
+    val message: String
 ) {
     companion object {
         fun from(map: Any) = object {
             val phase = Utils.getValue(map, arrayOf("phase")) ?: ""
 
+            val conditions = Utils.getValue(map, arrayOf("conditions")) as? List<Map<String, Any>>
+
+            val notReadyCondition = conditions
+                ?.firstOrNull { it["status"] == "False" }
+            val message = notReadyCondition?.get("message") as? String ?: ""
+
             val data = DevWorkspaceStatus(
-                phase as String
+                phase as String,
+                message
             )
         }.data
     }

--- a/src/main/kotlin/com/redhat/devtools/gateway/server/RemoteIDEServerStatus.kt
+++ b/src/main/kotlin/com/redhat/devtools/gateway/server/RemoteIDEServerStatus.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Red Hat, Inc.
+ * Copyright (c) 2024-2025 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -13,18 +13,19 @@
 package com.redhat.devtools.gateway.server
 
 data class RemoteIDEServerStatus(
-    val joinLink: String,
-    val httpLink: String,
-    val gatewayLink: String,
+    val joinLink: String?,
+    val httpLink: String?,
+    val gatewayLink: String?,
     val appVersion: String,
     val runtimeVersion: String,
-    val projects: Array<ProjectInfo>
+    val projects: Array<ProjectInfo>?
 ) {
     companion object {
         fun empty(): RemoteIDEServerStatus {
             return RemoteIDEServerStatus("", "", "", "", "", emptyArray())
         }
     }
+
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (javaClass != other?.javaClass) return false
@@ -36,19 +37,26 @@ data class RemoteIDEServerStatus(
         if (gatewayLink != other.gatewayLink) return false
         if (appVersion != other.appVersion) return false
         if (runtimeVersion != other.runtimeVersion) return false
-        if (!projects.contentEquals(other.projects)) return false
+        if (projects != null) {
+            if (other.projects == null || !projects.contentEquals(other.projects)) return false
+        } else if (other.projects != null) {
+            return false
+        }
 
         return true
     }
 
     override fun hashCode(): Int {
-        var result = joinLink.hashCode()
-        result = 31 * result + httpLink.hashCode()
-        result = 31 * result + gatewayLink.hashCode()
+        var result = joinLink?.hashCode() ?: 0
+        result = 31 * result + (httpLink?.hashCode() ?: 0)
+        result = 31 * result + (gatewayLink?.hashCode() ?: 0)
         result = 31 * result + appVersion.hashCode()
         result = 31 * result + runtimeVersion.hashCode()
-        result = 31 * result + projects.contentHashCode()
+        result = 31 * result + (projects?.contentHashCode() ?: 0)
         return result
     }
+
+    val isReady: Boolean
+        get() = !joinLink.isNullOrBlank() && !projects.isNullOrEmpty()
 }
 


### PR DESCRIPTION
When the DevSpaces WS isn't started or ready, this PR starts the WS and waits for its readiness before starting the Remote IDE Client:

https://github.com/user-attachments/assets/f28c28ce-68e0-494c-9077-334981fb921a

In some cases the Remote IDE Server cannot correctly process requests (status/stop) - usually when this happens we have no other option to recover, but the full DevSpaces Pod restart. so. with this PR, the User is asked to restart and if agreed, the DevSpaces Pod gets terminated and then restarted, which in its turn makes the Remote IDE server to correctly start:

https://github.com/user-attachments/assets/3614cb91-bb3d-465c-997b-f01477c4dd02

Fixes https://github.com/eclipse-che/che/issues/23485