### PR TITLE
fix: avoid bind exception when reconnecting after failure

### DIFF
--- a/src/main/kotlin/com/redhat/devtools/gateway/DevSpacesConnectionProvider.kt
+++ b/src/main/kotlin/com/redhat/devtools/gateway/DevSpacesConnectionProvider.kt
@@ -164,7 +164,7 @@ class DevSpacesConnectionProvider : GatewayConnectionProvider {
         parameters: Map<String, String>,
         requestor: ConnectionRequestor,
         indicator: ProgressIndicator? = null
-    ): GatewayConnectionHandle? {
+    ): GatewayConnectionHandle {
         thisLogger().debug("Launched Dev Spaces connection provider", parameters)
 
         indicator?.text2 = "Preparing connection environment…"

--- a/src/main/kotlin/com/redhat/devtools/gateway/server/RemoteIDEServerStatus.kt
+++ b/src/main/kotlin/com/redhat/devtools/gateway/server/RemoteIDEServerStatus.kt
@@ -13,7 +13,7 @@
 package com.redhat.devtools.gateway.server
 
 data class RemoteIDEServerStatus(
-    val joinLink: String,
+    val joinLink: String?,
     val httpLink: String,
     val gatewayLink: String,
     val appVersion: String,


### PR DESCRIPTION
When trying to connect to a workspace via link and it then fails, you get a `BindException` if you try again. That's because the server socket, that's used to forward, isn't closed if connecting fails.