### PR TITLE
move Throwable.rootMessage() to helper class

### DIFF
--- a/src/main/kotlin/com/redhat/devtools/gateway/util/ExceptionUtils.kt
+++ b/src/main/kotlin/com/redhat/devtools/gateway/util/ExceptionUtils.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2025 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package com.redhat.devtools.gateway.util
+
+fun Throwable.rootMessage(): String {
+    var cause: Throwable? = this
+    while (cause?.cause != null) {
+        cause = cause.cause
+    }
+    return cause?.message?.trim()
+        ?: this.message?.substringAfter(":")?.trim()
+        ?: "Unknown error"
+}

--- a/src/main/kotlin/com/redhat/devtools/gateway/view/steps/DevSpacesOpenShiftConnectionStepView.kt
+++ b/src/main/kotlin/com/redhat/devtools/gateway/view/steps/DevSpacesOpenShiftConnectionStepView.kt
@@ -28,6 +28,7 @@ import com.redhat.devtools.gateway.openshift.OpenShiftClientFactory
 import com.redhat.devtools.gateway.openshift.Projects
 import com.redhat.devtools.gateway.openshift.kube.KubeConfigBuilder
 import com.redhat.devtools.gateway.settings.DevSpacesSettings
+import com.redhat.devtools.gateway.util.rootMessage
 import com.redhat.devtools.gateway.view.InformationDialog
 import com.redhat.devtools.gateway.view.ui.FilteringComboBox
 import com.redhat.devtools.gateway.view.ui.PasteClipboardMenu
@@ -116,17 +117,6 @@ class DevSpacesOpenShiftConnectionStepView(private var devSpacesContext: DevSpac
         }
 
         return success
-    }
-
-    private fun Throwable.rootMessage(): String {
-        // Walk down to the root cause
-        var cause: Throwable? = this
-        while (cause?.cause != null) {
-            cause = cause.cause
-        }
-        return cause?.message?.trim()
-            ?: this.message?.substringAfter(":")?.trim()
-            ?: "Unknown error"
     }
 
     private fun loadOpenShiftConnectionSettings() {


### PR DESCRIPTION
follows up on #162

extracts `Throwable#rootMessage` to reusable utils