### PR TITLE
feat: increase wizard borders for nicer looks

### DIFF
--- a/src/main/kotlin/com/redhat/devtools/gateway/view/DevSpacesMainView.kt
+++ b/src/main/kotlin/com/redhat/devtools/gateway/view/DevSpacesMainView.kt
@@ -21,6 +21,6 @@ class DevSpacesMainView : GatewayConnectorView {
 
     override val component: JComponent
         get() = Wrapper(DevSpacesWizardView(DevSpacesContext())).apply {
-            border = JBUI.Borders.empty()
+            border = JBUI.Borders.empty(10, 20, 6, 20)
         }
 }


### PR DESCRIPTION
depends on #171

before:
<img width="799" height="649" alt="image" src="https://github.com/user-attachments/assets/8fc92492-561b-4ce3-af68-bea1c8e66664" />

after this change:
<img width="799" height="1298" alt="image" src="https://github.com/user-attachments/assets/215a8650-631e-4352-9473-0544e8f80b40" />