### PR TITLE
fix: dont allow double-clk on non-running ws (#23581)

### DIFF
--- a/src/main/kotlin/com/redhat/devtools/gateway/view/steps/DevSpacesWorkspacesStepView.kt
+++ b/src/main/kotlin/com/redhat/devtools/gateway/view/steps/DevSpacesWorkspacesStepView.kt
@@ -89,7 +89,7 @@ class DevSpacesWorkspacesStepView(
     override fun onInit() {
         listDevWorkspaces.selectionModel.addListSelectionListener(DevWorkspaceSelection())
         listDevWorkspaces.onDoubleClick { 
-            if (!listDevWorkspaces.isSelectionEmpty) {
+            if (isRunning(getSelectedWorkspace())) {
                 connect()
             }
         }


### PR DESCRIPTION
fixes https://github.com/eclipse-che/che/issues/23581