### PR TITLE
fix: Gateway: "Connect to Dev Spaces" wizard is to show only IDEA-based editor Workspaces

### DIFF
--- a/src/main/kotlin/com/redhat/devtools/gateway/openshift/DevWorkspace.kt
+++ b/src/main/kotlin/com/redhat/devtools/gateway/openshift/DevWorkspace.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Red Hat, Inc.
+ * Copyright (c) 2024-2025 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -43,6 +43,11 @@ data class DevWorkspace(
             return status.running
         }
 
+    val editor: String
+        get() {
+            return metadata.editor
+        }
+
     companion object {
         fun from(map: Any?) = object {
             val metadata = Utils.getValue(map, arrayOf("metadata")) ?: emptyMap<String, Any>()
@@ -65,6 +70,7 @@ data class DevWorkspace(
 
         if (metadata.name != other.metadata.name) return false
         if (metadata.namespace != other.metadata.namespace) return false
+        if (metadata.editor != other.metadata.editor) return false
 
         return true
     }
@@ -79,16 +85,19 @@ data class DevWorkspace(
 
 data class DevWorkspaceObjectMeta(
     val name: String,
-    val namespace: String
+    val namespace: String,
+    val editor: String
 ) {
     companion object {
         fun from(map: Any) = object {
             val name = Utils.getValue(map, arrayOf("name"))
             val namespace = Utils.getValue(map, arrayOf("namespace"))
+            val editor = Utils.getValue(map, arrayOf("annotations", "che.eclipse.org/che-editor")) ?: "unknown"
 
             val data = DevWorkspaceObjectMeta(
                 name as String,
-                namespace as String
+                namespace as String,
+                editor as String
             )
         }.data
     }

--- a/src/main/kotlin/com/redhat/devtools/gateway/openshift/DevWorkspaces.kt
+++ b/src/main/kotlin/com/redhat/devtools/gateway/openshift/DevWorkspaces.kt
@@ -48,6 +48,11 @@ class DevWorkspaces(private val client: ApiClient) {
             return dwItems
                 .stream()
                 .map { dwItem -> DevWorkspace.from(dwItem) }
+                .filter {
+                    val parts = it.editor.split("/")
+                    val segment = parts.getOrNull(1) ?: return@filter false
+                    Regex("che-.*-server").matches(segment)
+                }
                 .toList()
         } catch (e: ApiException) {
             thisLogger().info(e.message)


### PR DESCRIPTION
The PR makes the "Connect to Dev Spaces -> Select running DevWorkspace" wizard page show only JetBrains IDEA editor based workspaces.

Currently, the JetBrains-based editor IDs conform the following pattern: `<repository>/che-*-server/<version>`, so any WS created with an editor with ID that matches such a pattern will be shown in the Wizard:

<img width="1041" height="668" alt="image" src="https://github.com/user-attachments/assets/4c0b4fb8-9766-44c4-9798-a98aebc4c46f" />

... while any WS created with the [default] Che Code editor (f.i., `che-incubator/che-code/latest`) will not be displayed here 

Fixes: https://github.com/eclipse-che/che/issues/23584
Fixes: https://github.com/eclipse-che/che/issues/23582