### PR TITLE
fix: Gateway: Make it possible to restart WS when it cannot be created and launched in reasonable time

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -66,7 +66,7 @@ dependencies {
         testFramework(TestFrameworkType.JUnit5)
     }
 
-    implementation("io.kubernetes:client-java:24.0.0")
+    implementation("io.kubernetes:client-java:25.0.0")
     implementation("com.fasterxml.jackson.core:jackson-databind:2.20.1")
     implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.20.1")
 }

--- a/src/main/kotlin/com/redhat/devtools/gateway/DevSpacesConnection.kt
+++ b/src/main/kotlin/com/redhat/devtools/gateway/DevSpacesConnection.kt
@@ -41,7 +41,7 @@ class DevSpacesConnection(private val devSpacesContext: DevSpacesContext) {
         onConnected: () -> Unit,
         onDisconnected: () -> Unit,
         onDevWorkspaceStopped: () -> Unit,
-        onProgress: ((value: Any) -> Unit)? = null,
+        onProgress: ((value: ProgressCountdown.ProgressEvent) -> Unit)? = null,
         checkCancelled: (() -> Unit)? = null
     ): ThinClientHandle = runBlocking {
         doConnect(onConnected, onDevWorkspaceStopped, onDisconnected, onProgress, checkCancelled)
@@ -53,7 +53,7 @@ class DevSpacesConnection(private val devSpacesContext: DevSpacesContext) {
         onConnected: () -> Unit,
         onDevWorkspaceStopped: () -> Unit,
         onDisconnected: () -> Unit,
-        onProgress: ((value: Any) -> Unit)? = null,
+        onProgress: ((value: ProgressCountdown.ProgressEvent) -> Unit)? = null,
         checkCancelled: (() -> Unit)? = null
     ): ThinClientHandle {
         val workspace = devSpacesContext.devWorkspace
@@ -120,7 +120,8 @@ class DevSpacesConnection(private val devSpacesContext: DevSpacesContext) {
                 ?: throw IOException("Could not connect, remote IDE is not ready. No join link present.")
 
             checkCancelled?.invoke()
-            onProgress?.invoke("Waiting for the IDE client to start up...")
+            onProgress?.invoke(ProgressCountdown.ProgressEvent(
+                message = "Waiting for the IDE client to start up..."))
 
             val pods = Pods(devSpacesContext.client)
             val localPort = findFreePort()

--- a/src/main/kotlin/com/redhat/devtools/gateway/DevSpacesConnectionProvider.kt
+++ b/src/main/kotlin/com/redhat/devtools/gateway/DevSpacesConnectionProvider.kt
@@ -111,6 +111,8 @@ class DevSpacesConnectionProvider : GatewayConnectionProvider {
                             )
                         }
                         cont.resume(null)
+                    } finally {
+                        indicator.dispose()
                     }
                 },
                 "Connecting to Remote IDE...",
@@ -202,17 +204,8 @@ class DevSpacesConnectionProvider : GatewayConnectionProvider {
         indicator.update(message = "Establishing remote IDE connection…")
         val thinClient = DevSpacesConnection(ctx)
             .connect({}, {}, {},
-                onProgress = { value: Any ->
-                    when (val v = value) {
-                        is String -> {
-                            if (!v.isEmpty()) {
-                                indicator.text2 = v
-                            }
-                        }
-                        is ProgressCountdown.ProgressEvent -> {
-                            indicator.update(value.title, value.message, value.countdownSeconds)
-                        }
-                    }
+                onProgress = { value ->
+                    indicator.update(value.title, value.message, value.countdownSeconds)
                 },
                 checkCancelled = {
                     if (indicator.isCanceled) throw CancellationException("User cancelled the operation")

--- a/src/main/kotlin/com/redhat/devtools/gateway/openshift/ContainerAwareExec.kt
+++ b/src/main/kotlin/com/redhat/devtools/gateway/openshift/ContainerAwareExec.kt
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2025 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package com.redhat.devtools.gateway.openshift
+
+import com.redhat.devtools.gateway.util.isCancellationException
+import io.kubernetes.client.Exec
+import io.kubernetes.client.custom.IOTrio
+import io.kubernetes.client.openapi.ApiClient
+import kotlinx.coroutines.*
+import java.io.IOException
+import java.util.concurrent.CompletableFuture
+import java.util.function.BiConsumer
+import java.util.function.Consumer
+
+class ContainerAwareExec(
+    client: ApiClient,
+    private val parentScope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+) : Exec(client) {
+
+    data class ExecHandle(
+        val future: CompletableFuture<Int>,
+        val job: Job,
+        val io: IOTrio
+    )
+
+    @Throws(IOException::class)
+    fun containerAwareExec(
+        namespace: String,
+        pod: String,
+        container: String,
+        command: Array<String>,
+        onOpen: Consumer<IOTrio>?,
+        onClosed: BiConsumer<Int, IOTrio>?,
+        onError: BiConsumer<Throwable, IOTrio>?,
+        timeoutMs: Long?,
+        tty: Boolean
+    ): ExecHandle {
+
+        val io = IOTrio()
+        val future = CompletableFuture<Int>()
+        var process: Process? = null
+
+        val job = parentScope.launch {
+            try {
+                process = super.exec(
+                    namespace,
+                    pod,
+                    arrayOf(*command),
+                    container,
+                    true,
+                    tty
+                )
+
+                io.stdin = process!!.outputStream
+                io.stdout = process.inputStream
+                io.stderr = process.errorStream
+
+                onOpen?.accept(io)
+
+                val exitCode = withTimeoutOrNull(timeoutMs ?: Long.MAX_VALUE) {
+                    while (isActive) {
+                        if (!process.isAlive) {
+                            return@withTimeoutOrNull process.exitValue()
+                        }
+                        delay(50)
+                    }
+                    throw CancellationException()
+                }
+
+                val finalCode =
+                    if (exitCode == null) {
+                        safeTerminateProcess(process)
+                        Int.MAX_VALUE
+                    } else exitCode
+
+                onClosed?.accept(finalCode, io)
+                future.complete(finalCode)
+
+            } catch (t: Throwable) {
+                onError?.accept(t, io)
+                future.completeExceptionally(t)
+                throw t
+            }
+        }
+
+        job.invokeOnCompletion { cause ->
+            if (cause?.isCancellationException() == true) {
+                process?.let { safeTerminateProcess(it) }
+                future.cancel(true)
+            }
+        }
+
+        return ExecHandle(future, job, io)
+    }
+
+    private fun safeTerminateProcess(process: Process) {
+        try { process.inputStream.close() } catch (_: Throwable) {}
+        try { process.errorStream.close() } catch (_: Throwable) {}
+        try { process.outputStream.close() } catch (_: Throwable) {}
+        try { process.destroyForcibly() } catch (_: Throwable) {}
+    }
+}

--- a/src/main/kotlin/com/redhat/devtools/gateway/openshift/ContainerAwareExec.kt
+++ b/src/main/kotlin/com/redhat/devtools/gateway/openshift/ContainerAwareExec.kt
@@ -28,8 +28,7 @@ class ContainerAwareExec(
 
     data class ExecHandle(
         val future: CompletableFuture<Int>,
-        val job: Job,
-        val io: IOTrio
+        val job: Job
     )
 
     @Throws(IOException::class)
@@ -99,7 +98,7 @@ class ContainerAwareExec(
             }
         }
 
-        return ExecHandle(future, job, io)
+        return ExecHandle(future, job)
     }
 
     private fun safeTerminateProcess(process: Process) {

--- a/src/main/kotlin/com/redhat/devtools/gateway/server/RemoteIDEServer.kt
+++ b/src/main/kotlin/com/redhat/devtools/gateway/server/RemoteIDEServer.kt
@@ -85,12 +85,12 @@ class RemoteIDEServer(private val devSpacesContext: DevSpacesContext) {
         isReadyState: Boolean,
         checkCancelled: (() -> Unit)? = null
     ): Boolean {
-        try {
-            return getStatus(checkCancelled).isReady == isReadyState
+        return try {
+            getStatus(checkCancelled).isReady == isReadyState
         } catch (e: Exception) {
             if (e.isCancellationException()) throw e
             thisLogger().debug("Failed to check remote IDE server state.", e)
-            return false
+            false
         }
     }
 

--- a/src/main/kotlin/com/redhat/devtools/gateway/util/ExceptionUtils.kt
+++ b/src/main/kotlin/com/redhat/devtools/gateway/util/ExceptionUtils.kt
@@ -13,6 +13,9 @@ package com.redhat.devtools.gateway.util
 
 import com.google.gson.Gson
 import io.kubernetes.client.openapi.ApiException
+import kotlinx.coroutines.TimeoutCancellationException
+import java.util.concurrent.CancellationException
+import java.util.concurrent.TimeoutException
 
 
 fun Throwable.rootMessage(): String {
@@ -48,3 +51,6 @@ fun ApiException.message(): String {
     return "Reason: $msg"
 }
 
+fun Throwable.isTimeoutException(): Boolean = (this is TimeoutCancellationException || this is TimeoutException )
+
+fun Throwable.isCancellationException(): Boolean = (this is CancellationException && !isTimeoutException() )

--- a/src/main/kotlin/com/redhat/devtools/gateway/util/ProgressCountdown.kt
+++ b/src/main/kotlin/com/redhat/devtools/gateway/util/ProgressCountdown.kt
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2025 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package com.redhat.devtools.gateway.util
+
+import com.intellij.openapi.progress.ProgressIndicator
+import kotlinx.coroutines.*
+import kotlin.time.Duration.Companion.seconds
+
+class ProgressCountdown(private val delegate: ProgressIndicator) : ProgressIndicator by delegate {
+    private var job: Job? = null
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    private var baseText2: String? = null
+
+    companion object {
+        const val EN_DASH = "\u2013"
+    }
+
+    fun update(
+        title: String? = null,
+        message: String? = null,
+        countdownSeconds: Long? = null
+    ) {
+        title?.let { delegate.text = it }
+        message?.let {
+            baseText2 = it
+            delegate.text2 = it
+        }
+
+        if (countdownSeconds != null && countdownSeconds > 0) startCountdown(countdownSeconds)
+        else stopCountdown()
+    }
+
+    private fun startCountdown(seconds: Long) {
+        job?.cancel()
+        var remaining = seconds
+        job = scope.launch {
+            while (remaining > 0 && isActive && !delegate.isCanceled) {
+                delegate.text2 = buildText2WithSuffix(remaining)
+                delay(1.seconds)
+                remaining--
+            }
+            delegate.text2 = baseText2
+        }
+    }
+
+    fun stopCountdown() {
+        job?.cancel()
+        job = null
+        delegate.text2 = baseText2
+    }
+
+    fun dispose() {
+        stopCountdown()
+        scope.cancel()
+    }
+
+    private fun buildText2WithSuffix(secondsLeft: Long): String =
+        buildString {
+            baseText2?.let { append(it) }
+            append(" \t$EN_DASH $secondsLeft second${if (secondsLeft != 1L) "s" else ""} left")
+        }
+
+    data class ProgressEvent (
+        val title: String? = null,
+        val message: String? = null,
+        val countdownSeconds: Long? = null
+    )
+}

--- a/src/main/kotlin/com/redhat/devtools/gateway/util/ProgressCountdown.kt
+++ b/src/main/kotlin/com/redhat/devtools/gateway/util/ProgressCountdown.kt
@@ -11,11 +11,12 @@
  */
 package com.redhat.devtools.gateway.util
 
+import com.intellij.openapi.Disposable
 import com.intellij.openapi.progress.ProgressIndicator
 import kotlinx.coroutines.*
 import kotlin.time.Duration.Companion.seconds
 
-class ProgressCountdown(private val delegate: ProgressIndicator) : ProgressIndicator by delegate {
+class ProgressCountdown(private val delegate: ProgressIndicator) : ProgressIndicator by delegate, Disposable {
     private var job: Job? = null
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
     private var baseText2: String? = null
@@ -58,7 +59,7 @@ class ProgressCountdown(private val delegate: ProgressIndicator) : ProgressIndic
         delegate.text2 = baseText2
     }
 
-    fun dispose() {
+    override fun dispose() {
         stopCountdown()
         scope.cancel()
     }


### PR DESCRIPTION
In case of Remote IDE Server doesn't return "ready" status (containing the Join Link and the projects) in reasonable time we can suggest users to restart the Pod:

<img width="801" height="655" alt="image" src="https://github.com/user-attachments/assets/39ca643c-5979-44e1-adba-d05f86d06577" />


Fixes: https://github.com/eclipse-che/che/issues/23615