### PR TITLE
feat: allow connect to ws without project (#23812,crw-10683)

### DIFF
--- a/src/main/kotlin/com/redhat/devtools/gateway/DevSpacesConnection.kt
+++ b/src/main/kotlin/com/redhat/devtools/gateway/DevSpacesConnection.kt
@@ -11,9 +11,7 @@
  */
 package com.redhat.devtools.gateway
 
-import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.diagnostic.thisLogger
-import com.intellij.openapi.ui.Messages
 import com.jetbrains.gateway.thinClientLink.LinkedClientManager
 import com.jetbrains.gateway.thinClientLink.ThinClientHandle
 import com.jetbrains.rd.util.lifetime.Lifetime
@@ -23,7 +21,7 @@ import com.redhat.devtools.gateway.server.RemoteIDEServer
 import com.redhat.devtools.gateway.server.RemoteIDEServerStatus
 import com.redhat.devtools.gateway.util.ProgressCountdown
 import com.redhat.devtools.gateway.util.isCancellationException
-import io.kubernetes.client.openapi.ApiException
+import com.redhat.devtools.gateway.view.ui.Dialogs
 import kotlinx.coroutines.*
 import java.io.Closeable
 import java.io.IOException
@@ -31,7 +29,7 @@ import java.net.ServerSocket
 import java.net.URI
 import java.util.concurrent.CancellationException
 import java.util.concurrent.atomic.AtomicBoolean
-import java.util.concurrent.atomic.AtomicInteger
+import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
 class DevSpacesConnection(private val devSpacesContext: DevSpacesContext) {
@@ -68,14 +66,18 @@ class DevSpacesConnection(private val devSpacesContext: DevSpacesContext) {
             while (!remoteIdeServerStatus.isReady) {
                 checkCancelled?.invoke()
                 onProgress?.invoke(ProgressCountdown.ProgressEvent(
-                    message = "Waiting for the Dev Workspace to get ready...",
+                    message = "Waiting for the workspace to get ready...",
                     countdownSeconds = DevWorkspaces.RUNNING_TIMEOUT))
 
-                startAndWaitDevWorkspace(checkCancelled)
+                DevWorkspaces(devSpacesContext.client)
+                    .startAndWait(
+                        devSpacesContext.devWorkspace.namespace,
+                        devSpacesContext.devWorkspace.name,
+                        checkCancelled = checkCancelled)
 
                 checkCancelled?.invoke()
                 onProgress?.invoke(ProgressCountdown.ProgressEvent(
-                    message = "Waiting for the remote server to get ready...",
+                    message = "Waiting for the workspace to get ready...",
                     countdownSeconds = RemoteIDEServer.readyTimeout))
 
                 remoteIdeServer = RemoteIDEServer(devSpacesContext)
@@ -88,40 +90,31 @@ class DevSpacesConnection(private val devSpacesContext: DevSpacesContext) {
 
                 checkCancelled?.invoke()
                 if (!remoteIdeServerStatus.isReady) {
-                    val result = AtomicInteger(-1)
-                    ApplicationManager.getApplication().invokeAndWait {
-                        result.set(
-                            Messages.showDialog(
-                                "The remote server is not responding properly.\n" +
-                                        "Would you like to try restarting the Pod or cancel the connection?",
-                                "Cannot Connect to Server",
-                                arrayOf("Cancel Connection", "Restart Pod and try again"),
-                                0,  // default selected index
-                                Messages.getWarningIcon()
-                            )
+                    val restartWorkspace = Dialogs.ideNotResponding()
+
+                    if (restartWorkspace) {
+                        // User chose "Restart Pod": stop the Pod and try starting from scratch
+                        DevWorkspaces(devSpacesContext.client).stopAndWait(
+                            devSpacesContext.devWorkspace.namespace,
+                            devSpacesContext.devWorkspace.name,
+                            checkCancelled = checkCancelled
                         )
+                        continue
+                    } else {
+                        // User chose "Cancel Connection"
+                        throw CancellationException("User cancelled the operation")
                     }
-
-                    when (result.get()) {
-                        1 -> {
-                            // User chose "Restart Pod": stop the Pod and try starting from scratch
-                            stopAndWaitDevWorkspace(checkCancelled)
-                            continue
-                        }
-                    }
-
-                    // User chose "Cancel Connection"
-                    throw CancellationException("User cancelled the operation")
                 }
             }
 
-            check(remoteIdeServer != null && remoteIdeServerStatus.isReady) { "Could not connect, remote IDE is not ready." }
+            checkCancelled?.invoke()
             val joinLink = remoteIdeServerStatus.joinLink
-                ?: throw IOException("Could not connect, remote IDE is not ready. No join link present.")
+                ?: throw IOException("Could not connect, workspace IDE is not ready. No join link present.")
 
+            check(remoteIdeServer != null)
             checkCancelled?.invoke()
             onProgress?.invoke(ProgressCountdown.ProgressEvent(
-                message = "Waiting for the IDE client to start up..."))
+                message = "Waiting for the workspace IDE client to start..."))
 
             val pods = Pods(devSpacesContext.client)
             val localPort = findFreePort()
@@ -159,14 +152,14 @@ class DevSpacesConnection(private val devSpacesContext: DevSpacesContext) {
             val success = withTimeoutOrNull(60.seconds) {
                 while (!finished.get()) {
                     checkCancelled?.invoke()
-                    delay(200)
+                    delay(200.milliseconds)
                 }
                 true
             } ?: false
 
             // Check if the thin client has opened
             check(success && client.clientPresent) {
-                "Could not connect, remote IDE client is not ready."
+                "Could not connect, workspace IDE is not ready."
             }
 
             onConnected()
@@ -215,63 +208,5 @@ class DevSpacesConnection(private val devSpacesContext: DevSpacesContext) {
             socket.reuseAddress = true
             return socket.localPort
         }
-    }
-
-    @Throws(IOException::class, ApiException::class, CancellationException::class)
-    private fun startAndWaitDevWorkspace(checkCancelled: (() -> Unit)? = null) {
-        // We really need a refreshed DevWorkspace here
-        val devWorkspace = DevWorkspaces(devSpacesContext.client).get(
-            devSpacesContext.devWorkspace.namespace,
-            devSpacesContext.devWorkspace.name)
-
-        if (!devWorkspace.started) {
-            checkCancelled?.invoke()
-            DevWorkspaces(devSpacesContext.client)
-                .start(
-                    devSpacesContext.devWorkspace.namespace,
-                    devSpacesContext.devWorkspace.name
-                )
-        }
-
-        if (!runBlocking { DevWorkspaces(devSpacesContext.client)
-                .waitPhase(
-                    devSpacesContext.devWorkspace.namespace,
-                    devSpacesContext.devWorkspace.name,
-                    DevWorkspaces.RUNNING,
-                    DevWorkspaces.RUNNING_TIMEOUT,
-                    checkCancelled
-            ) }
-        ) throw IOException(
-            "DevWorkspace '${devSpacesContext.devWorkspace.name}' is not running after ${DevWorkspaces.RUNNING_TIMEOUT} seconds"
-        )
-    }
-
-    @Throws(IOException::class, ApiException::class, CancellationException::class)
-    private fun stopAndWaitDevWorkspace(checkCancelled: (() -> Unit)? = null) {
-        // We really need a refreshed DevWorkspace here
-        val devWorkspace = DevWorkspaces(devSpacesContext.client).get(
-            devSpacesContext.devWorkspace.namespace,
-            devSpacesContext.devWorkspace.name)
-
-        if (devWorkspace.started) {
-            checkCancelled?.invoke()
-            DevWorkspaces(devSpacesContext.client)
-                .stop(
-                    devSpacesContext.devWorkspace.namespace,
-                    devSpacesContext.devWorkspace.name
-                )
-        }
-
-        if (!runBlocking { DevWorkspaces(devSpacesContext.client)
-                .waitPhase(
-                    devSpacesContext.devWorkspace.namespace,
-                    devSpacesContext.devWorkspace.name,
-                    DevWorkspaces.STOPPED,
-                    DevWorkspaces.RUNNING_TIMEOUT,
-                    checkCancelled
-                ) }
-        ) throw IOException(
-            "DevWorkspace '${devSpacesContext.devWorkspace.name}' has not stopped after ${DevWorkspaces.RUNNING_TIMEOUT} seconds"
-        )
     }
 }

--- a/src/main/kotlin/com/redhat/devtools/gateway/DevSpacesConnectionHandle.kt
+++ b/src/main/kotlin/com/redhat/devtools/gateway/DevSpacesConnectionHandle.kt
@@ -26,12 +26,12 @@ class DevSpacesConnectionHandle(
     private val wsName: String
 ) : GatewayConnectionHandle(lifetime, clientHandle) {
     override fun customComponentProvider(lifetime: Lifetime) = object : CustomConnectionFrameComponentProvider {
-        override val closeConfirmationText = "Disconnect from DevWorkspace ${wsName}?"
+        override val closeConfirmationText = "Disconnect from workspace ${wsName}?"
         override fun createComponent(context: CustomConnectionFrameContext) = componentProvider.invoke()
     }
 
     override fun getTitle(): String {
-        return "DevWorkspace $wsName"
+        return "Workspace $wsName"
     }
 
     override fun hideToTrayOnStart(): Boolean {

--- a/src/main/kotlin/com/redhat/devtools/gateway/DevSpacesConnectionProvider.kt
+++ b/src/main/kotlin/com/redhat/devtools/gateway/DevSpacesConnectionProvider.kt
@@ -68,7 +68,7 @@ class DevSpacesConnectionProvider : GatewayConnectionProvider {
                         val thinClient = handle.clientHandle
                             ?: throw RuntimeException("Failed to obtain ThinClientHandle")
 
-                        indicator.text = "Waiting for remote IDE to start..."
+                        indicator.text = "Waiting for workspace IDE to start..."
 
                         val ready = CompletableDeferred<GatewayConnectionHandle?>()
 
@@ -115,7 +115,7 @@ class DevSpacesConnectionProvider : GatewayConnectionProvider {
                         indicator.dispose()
                     }
                 },
-                "Connecting to Remote IDE...",
+                "Connecting to Workspace IDE...",
                 true,
                 null
             )
@@ -129,7 +129,7 @@ class DevSpacesConnectionProvider : GatewayConnectionProvider {
     ): (Unit) -> Unit = {
         ApplicationManager.getApplication().invokeLater {
             if (!ready.isCompleted) {
-                indicator.text = "Remote IDE has started successfully"
+                indicator.text = "Workspace IDE has started successfully"
                 indicator.text2 = "Opening project window…"
                 runDelayed(3000) {
                     if (indicator.isRunning) indicator.stop()
@@ -160,7 +160,7 @@ class DevSpacesConnectionProvider : GatewayConnectionProvider {
     ): (Unit) -> Unit = {
         ApplicationManager.getApplication().invokeLater {
             if (!ready.isCompleted) {
-                indicator.text = "Remote IDE closed unexpectedly."
+                indicator.text = "Workspace IDE closed unexpectedly."
                 runDelayed(2000) {
                     if (indicator.isRunning) indicator.stop()
                     if (ready.isActive) ready.complete(null)
@@ -198,10 +198,10 @@ class DevSpacesConnectionProvider : GatewayConnectionProvider {
         this.clientFactory = factory
         ctx.client = factory.create()
 
-        indicator.update(message = "Fetching DevWorkspace “$dwName” from namespace “$dwNamespace”…")
+        indicator.update(message = "Fetching workspace “$dwName” from namespace “$dwNamespace”…")
         ctx.devWorkspace = DevWorkspaces(ctx.client).get(dwNamespace, dwName)
 
-        indicator.update(message = "Establishing remote IDE connection…")
+        indicator.update(message = "Connecting to workspace IDE…")
         val thinClient = DevSpacesConnection(ctx)
             .connect({}, {}, {},
                 onProgress = { value ->
@@ -260,7 +260,7 @@ class DevSpacesConnectionProvider : GatewayConnectionProvider {
         if (!err.isNotFound()) return false
 
         val message = """
-            Workspace or DevWorkspace support not found.
+            Workspace support not found.
             You're likely connected to a cluster that doesn't have the DevWorkspace Operator installed, or the specified workspace doesn't exist.
         
             Please verify your Kubernetes context, namespace, and that the DevWorkspace Operator is installed and running.

--- a/src/main/kotlin/com/redhat/devtools/gateway/openshift/DevWorkspaces.kt
+++ b/src/main/kotlin/com/redhat/devtools/gateway/openshift/DevWorkspaces.kt
@@ -20,9 +20,11 @@ import io.kubernetes.client.openapi.apis.CustomObjectsApi
 import io.kubernetes.client.util.PatchUtils
 import io.kubernetes.client.util.Watch
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeoutOrNull
 import java.io.IOException
 import java.util.concurrent.CancellationException
+import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
 data class DevWorkspaceListResult(
@@ -166,6 +168,44 @@ class DevWorkspaces(private val client: ApiClient) {
         doPatch(namespace, name, patch)
     }
 
+    @Throws(IOException::class, ApiException::class, CancellationException::class)
+    fun startAndWait(
+        namespace: String,
+        name: String,
+        timeout: Long = RUNNING_TIMEOUT,
+        checkCancelled: (() -> Unit)? = null
+    ) {
+        val devWorkspace = get(namespace, name)
+
+        if (!devWorkspace.started) {
+            checkCancelled?.invoke()
+            start(namespace, name)
+        }
+
+        if (!runBlocking { waitPhase(namespace, name, RUNNING, timeout, checkCancelled) }) {
+            throw IOException("Workspace '$name' is not running after $timeout seconds")
+        }
+    }
+
+    @Throws(IOException::class, ApiException::class, CancellationException::class)
+    fun stopAndWait(
+        namespace: String,
+        name: String,
+        timeout: Long = RUNNING_TIMEOUT,
+        checkCancelled: (() -> Unit)? = null
+    ) {
+        val devWorkspace = get(namespace, name)
+
+        if (devWorkspace.started) {
+            checkCancelled?.invoke()
+            stop(namespace, name)
+        }
+
+        if (!runBlocking { waitPhase(namespace, name, STOPPED, timeout, checkCancelled) }) {
+            throw IOException("Workspace '$name' has not stopped after $timeout seconds")
+        }
+    }
+
     @Throws(ApiException::class, IOException::class, CancellationException::class)
     suspend fun waitPhase(
         namespace: String,
@@ -180,7 +220,7 @@ class DevWorkspaces(private val client: ApiClient) {
                 val devWorkspace = try {
                     DevWorkspaces(client).get(namespace, name)
                 } catch (e: Exception) {
-                    delay(500)
+                    delay(500.milliseconds)
                     continue
                 }
 
@@ -190,7 +230,7 @@ class DevWorkspaces(private val client: ApiClient) {
                     FAILED, STOPPED, STOPPING -> return@withTimeoutOrNull false
                 }
 
-                delay(500)
+                delay(500.milliseconds)
             }
 
             @Suppress("UNREACHABLE_CODE")

--- a/src/main/kotlin/com/redhat/devtools/gateway/server/RemoteIDEServer.kt
+++ b/src/main/kotlin/com/redhat/devtools/gateway/server/RemoteIDEServer.kt
@@ -21,6 +21,8 @@ import io.kubernetes.client.openapi.models.V1Pod
 import kotlinx.coroutines.*
 import java.io.IOException
 import java.util.concurrent.CancellationException
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 
 /**
  * Represent an IDE server running in a CDE.
@@ -30,7 +32,7 @@ class RemoteIDEServer(private val devSpacesContext: DevSpacesContext) {
     private var container: V1Container
 
     companion object {
-        var readyTimeout: Long = 60
+        var readyTimeout: Long = 60 // seconds
     }
 
     init {
@@ -68,12 +70,19 @@ class RemoteIDEServer(private val devSpacesContext: DevSpacesContext) {
             } ?: RemoteIDEServerStatus.empty()
         }
 
+    /**
+     * Waits for the server to be ready for the given timeout period.
+     *
+     * @param checkCancelled the check for user cancellation.
+     * @param timeout maximum waiting period in seconds
+     * @return True if the server is ready within the timeout, False otherwise.
+     */
     @Throws(IOException::class)
     suspend fun waitServerReady(checkCancelled: (() -> Unit)? = null, timeout: Long = readyTimeout): Boolean {
         return doWaitServerState(true, timeout, checkCancelled)
             .also {
                 if (!it) throw IOException(
-                    "Remote IDE server is not ready after $readyTimeout seconds.",
+                    "Workspace IDE is not ready after $readyTimeout seconds.",
                 )
             }
     }
@@ -87,7 +96,7 @@ class RemoteIDEServer(private val devSpacesContext: DevSpacesContext) {
             getStatus(checkCancelled).isReady == isReadyState
         } catch (e: Exception) {
             if (e.isCancellationException()) throw e
-            thisLogger().debug("Failed to check remote IDE server state.", e)
+            thisLogger().debug("Failed to check workspace IDE state.", e)
             false
         }
     }
@@ -110,7 +119,7 @@ class RemoteIDEServer(private val devSpacesContext: DevSpacesContext) {
         timeout: Long = readyTimeout,
         checkCancelled: (() -> Unit)? = null
     ): Boolean =
-        withTimeoutOrNull(timeout * 1000) { // seconds → ms
+        withTimeoutOrNull(timeout.seconds) { // seconds → ms
             while (true) {
                 checkCancelled?.invoke()
                 if (isServerState(isReadyState, checkCancelled)) {
@@ -118,7 +127,7 @@ class RemoteIDEServer(private val devSpacesContext: DevSpacesContext) {
                 }
 
                 yield()
-                delay(500)
+                delay(500.milliseconds)
             }
 
             @Suppress("UNREACHABLE_CODE")
@@ -140,9 +149,11 @@ class RemoteIDEServer(private val devSpacesContext: DevSpacesContext) {
 
     @Throws(IOException::class)
     private fun findContainer(): V1Container {
-        return pod.spec!!.containers.find { container -> container.ports?.any { port -> port.name == "idea-server" } != null }
+        return pod.spec!!.containers.find { container ->
+            container.ports?.any { port -> port.name == "idea-server" } != null
+        }
             ?: throw IOException(
-                "Remote server container not found in the Pod: ${pod.metadata?.name}"
+                "Workspace IDE container not found in the Pod: ${pod.metadata?.name}"
             )
     }
 }

--- a/src/main/kotlin/com/redhat/devtools/gateway/server/RemoteIDEServerStatus.kt
+++ b/src/main/kotlin/com/redhat/devtools/gateway/server/RemoteIDEServerStatus.kt
@@ -29,7 +29,12 @@ data class RemoteIDEServerStatus(
     val isReady: Boolean
         get() {
             return !joinLink.isNullOrBlank()
-                && !projects.isNullOrEmpty() }
+        }
+
+    val hasProject: Boolean
+        get() {
+            return !projects.isNullOrEmpty()
+        }
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/src/main/kotlin/com/redhat/devtools/gateway/view/steps/DevSpacesWorkspacesStepView.kt
+++ b/src/main/kotlin/com/redhat/devtools/gateway/view/steps/DevSpacesWorkspacesStepView.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2026 Red Hat, Inc.
+ * Copyright (c) 2024-2025 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -17,6 +17,7 @@ import com.intellij.openapi.application.invokeLater
 import com.intellij.openapi.application.runInEdt
 import com.intellij.openapi.diagnostic.thisLogger
 import com.intellij.openapi.progress.ProgressManager
+import com.intellij.openapi.ui.MessageDialogBuilder
 import com.intellij.openapi.util.Disposer
 import com.intellij.openapi.wm.impl.welcomeScreen.WelcomeScreenUIManager
 import com.intellij.ui.ColoredListCellRenderer
@@ -31,6 +32,9 @@ import com.redhat.devtools.gateway.DevSpacesConnection
 import com.redhat.devtools.gateway.DevSpacesContext
 import com.redhat.devtools.gateway.DevSpacesIcons
 import com.redhat.devtools.gateway.openshift.*
+import com.redhat.devtools.gateway.server.RemoteIDEServer
+import com.redhat.devtools.gateway.server.RemoteIDEServerStatus
+import com.redhat.devtools.gateway.util.isCancellationException
 import com.redhat.devtools.gateway.util.messageWithoutPrefix
 import com.redhat.devtools.gateway.view.ui.Dialogs
 import com.redhat.devtools.gateway.view.ui.onDoubleClick
@@ -38,7 +42,11 @@ import io.kubernetes.client.openapi.ApiClient
 import kotlinx.coroutines.runBlocking
 import java.awt.Dimension
 import java.awt.FontMetrics
-import javax.swing.*
+import java.util.concurrent.CancellationException
+import javax.swing.DefaultListModel
+import javax.swing.JButton
+import javax.swing.JList
+import javax.swing.ListModel
 import javax.swing.event.ListSelectionEvent
 import javax.swing.event.ListSelectionListener
 
@@ -100,10 +108,8 @@ class DevSpacesWorkspacesStepView(
     override fun onInit() {
         listDWDataModel.clear() // avoid glitch where user would see old list content before it's cleared
         listDevWorkspaces.selectionModel.addListSelectionListener(DevWorkspaceSelection())
-        listDevWorkspaces.onDoubleClick { 
-            if (isRunning(getSelectedWorkspace())) {
-                connect()
-            }
+        listDevWorkspaces.onDoubleClick {
+            onNext()
         }
         listDevWorkspaces.cellRenderer = DevWorkspaceListRenderer()
         listDevWorkspaces.setEmptyText(DevSpacesBundle.message("connector.wizard_step.remote_server_connection.list.empty_text"))
@@ -120,11 +126,41 @@ class DevSpacesWorkspacesStepView(
     }
 
     override fun onNext(): Boolean {
-        watchManager?.stop()
-        if (!listDevWorkspaces.isSelectionEmpty) {
-            connect()
+        val workspace = getSelectedWorkspace() ?: return false
+        if (!isRunning(workspace)) {
+            return false
         }
-        return false
+        devSpacesContext.devWorkspace = workspace
+        val serverStatus = try {
+            getServerStatus()
+        } catch (e: Exception) {
+            if (e.isCancellationException()) {
+                return false // canceled, stay on this step
+            }
+            thisLogger().error("Could not check workspace IDE status", e)
+            if (Dialogs.ideNotResponding()) {
+                stopDevWorkspace()
+                connect()
+            }
+            return false
+        } ?: return false // Canceled, stay on this step
+
+        if (!serverStatus.hasProject) {
+            val proceed = MessageDialogBuilder
+                .yesNo(
+                    "Workspace IDE Without Project",
+                    "The Workspace IDE has no project.\nWould you like to connect anyway?"
+                )
+                .asWarning()
+                .yesText("Connect Anyway")
+                .noText("Cancel")
+                .ask(component)
+
+            if (!proceed) return false // Stay on this step
+        }
+
+        connect()
+        return false // Stay on this step after connection
     }
 
     private fun initListListeners(disposable: Disposable) {
@@ -208,22 +244,25 @@ class DevSpacesWorkspacesStepView(
 
     private fun startDevWorkspace() {
         val selectedWorkspace = getSelectedWorkspace() ?: return
-        DevWorkspaces(devSpacesContext.client)
-            .start(
-                selectedWorkspace.namespace,
-                selectedWorkspace.name
-            )
         ProgressManager.getInstance().runProcessWithProgressSynchronously(
             {
-                if (waitDevWorkspaceNotStopped(selectedWorkspace)) {
+                try {
+                    DevWorkspaces(devSpacesContext.client).start(
+                        selectedWorkspace.namespace,
+                        selectedWorkspace.name
+                    )
                     refreshDevWorkspace(
                         selectedWorkspace.namespace,
                         selectedWorkspace.name
                     )
                     enableButtons()
+                } catch (e: Exception) {
+                    thisLogger().error("Failed to start workspace", e)
+                    // UI already shows current state, just enable buttons
+                    enableButtons()
                 }
             },
-            "Refreshing Workspace",
+            "Starting Workspace",
             true,
             null
         )
@@ -231,34 +270,81 @@ class DevSpacesWorkspacesStepView(
 
     private fun stopDevWorkspace() {
         val selectedWorkspace = getSelectedWorkspace() ?: return
-        DevWorkspaces(devSpacesContext.client)
-            .stop(
-                selectedWorkspace.namespace,
-                selectedWorkspace.name
-            )
         ProgressManager.getInstance().runProcessWithProgressSynchronously(
             {
-                if (waitDevWorkspaceStopped(selectedWorkspace)) {
+                try {
+                    DevWorkspaces(devSpacesContext.client).stop(
+                        selectedWorkspace.namespace,
+                        selectedWorkspace.name
+                    )
                     refreshDevWorkspace(
                         selectedWorkspace.namespace,
                         selectedWorkspace.name
                     )
                     enableButtons()
+                } catch (e: Exception) {
+                    thisLogger().error("Failed to stop workspace", e)
+                    // UI already shows current state, just enable buttons
+                    enableButtons()
                 }
             },
-            "Refreshing Workspace",
+            "Stopping Workspace",
             true,
             null
         )
     }
 
-    private fun connect() {
-        getSelectedWorkspace().apply {
-            if (this != null) {
-                devSpacesContext.devWorkspace = this
-            }
-        }
+    private fun getServerStatus(): RemoteIDEServerStatus? {
+        var status: RemoteIDEServerStatus? = null
+        var errorToThrow: Exception? = null
 
+        ProgressManager.getInstance().runProcessWithProgressSynchronously(
+            {
+                try {
+                    val progressIndicator = ProgressManager.getInstance().progressIndicator
+                    progressIndicator.text = "Checking workspace IDE Status..."
+                    val checkCancelled = {
+                        if (progressIndicator.isCanceled) throw CancellationException()
+                    }
+
+                    if (!verifyWorkspaceRunning(checkCancelled)) {
+                        return@runProcessWithProgressSynchronously
+                    }
+
+                    val remoteIdeServer = RemoteIDEServer(devSpacesContext)
+                    status = runBlocking {
+                        remoteIdeServer.waitServerReady(checkCancelled)
+                        remoteIdeServer.getStatus()
+                    }
+                } catch (e: Exception) {
+                    if (e.isCancellationException()) {
+                        return@runProcessWithProgressSynchronously
+                    }
+                    errorToThrow = e
+                }
+            },
+            "Connect to Workspace IDE",
+            true,
+            null
+        )
+
+        errorToThrow?.let { throw it }
+        return status
+    }
+
+    private fun verifyWorkspaceRunning(checkCancelled: (() -> Unit)? = null): Boolean {
+        return runBlocking {
+            DevWorkspaces(devSpacesContext.client).waitPhase(
+                devSpacesContext.devWorkspace.namespace,
+                devSpacesContext.devWorkspace.name,
+                DevWorkspaces.RUNNING,
+                DevWorkspaces.RUNNING_TIMEOUT,
+                checkCancelled
+            )
+        }
+    }
+
+    private fun connect() {
         ProgressManager.getInstance().runProcessWithProgressSynchronously(
             {
                 try {
@@ -289,24 +375,14 @@ class DevSpacesWorkspacesStepView(
                         devSpacesContext.devWorkspace.name
                     )
                     enableButtons()
-                    thisLogger().error("Remote server connection failed.", e)
-                    Dialogs.error(e.messageWithoutPrefix() ?: "Could not connect to workspace", "Connection Error")
+                    thisLogger().error("Workspace IDE connection failed.", e)
+                    Dialogs.error(e.messageWithoutPrefix() ?: "Could not connect to workspace IDE", "Connection Error")
                 }
             },
             DevSpacesBundle.message("connector.loader.devspaces.connecting.text"),
             true,
             null
         )
-    }
-
-    private fun waitDevWorkspaceNotStopped(devWorkspace: DevWorkspace): Boolean {
-        return runBlocking { DevWorkspaces(devSpacesContext.client)
-            .waitPhaseChanges(
-                devWorkspace.namespace,
-                devWorkspace.name,
-                listOf(DevWorkspaces.STOPPED, DevWorkspaces.FAILED),
-                30
-            ) }
     }
 
     private fun waitDevWorkspaceStopped(devWorkspace: DevWorkspace): Boolean {

--- a/src/main/kotlin/com/redhat/devtools/gateway/view/ui/Dialogs.kt
+++ b/src/main/kotlin/com/redhat/devtools/gateway/view/ui/Dialogs.kt
@@ -2,6 +2,8 @@ package com.redhat.devtools.gateway.view.ui
 
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.ui.Messages
+import java.util.concurrent.atomic.AtomicInteger
+import javax.swing.Icon
 
 object Dialogs {
 
@@ -14,4 +16,95 @@ object Dialogs {
             )
         }
     }
+
+    /**
+     * Shows a dialog on the EDT and returns the selected button index.
+     *
+     * @param message The message to display
+     * @param title The dialog title
+     * @param options Array of button labels
+     * @param defaultOptionIndex The index of the default selected button
+     * @param icon The icon to display (optional)
+     * @return The index of the selected button
+     */
+    fun showInEdt(
+        message: String,
+        title: String,
+        options: Array<String>,
+        defaultOptionIndex: Int = 0,
+        icon: Icon? = Messages.getWarningIcon()
+    ): Int {
+        val result = AtomicInteger(-1)
+        ApplicationManager.getApplication().invokeAndWait {
+            result.set(
+                Messages.showDialog(
+                    message,
+                    title,
+                    options,
+                    defaultOptionIndex,
+                    icon
+                )
+            )
+        }
+        return result.get()
+    }
+
+    /**
+     * Shows a dialog and returns true if the user selected the specified option index.
+     *
+     * @param message The message to display
+     * @param title The dialog title
+     * @param buttons Array of button labels
+     * @param confirmOptionIndex The index of the button that should return true
+     * @param defaultOptionIndex The index of the default selected button
+     * @return true if the user selected the confirmOptionIndex, false otherwise
+     */
+    fun confirm(
+        message: String,
+        title: String,
+        buttons: Array<String>,
+        confirmOptionIndex: Int,
+        defaultOptionIndex: Int = 0
+    ): Boolean {
+        return showInEdt(
+            message,
+            title,
+            buttons,
+            defaultOptionIndex,
+            Messages.getWarningIcon()
+        ) == confirmOptionIndex
+    }
+
+    fun error(
+        message: String,
+        title: String,
+        buttons: Array<String>,
+        confirmOptionIndex: Int,
+        defaultOptionIndex: Int = 0
+    ): Boolean {
+        return showInEdt(
+            message,
+            title,
+            buttons,
+            defaultOptionIndex,
+            Messages.getErrorIcon()
+        ) == confirmOptionIndex
+    }
+
+    /**
+     * Shows a dialog for when the workspace IDE is not responding.
+     *
+     * @return true if the user wants to restart the Pod, false if they want to cancel the connection
+     */
+    fun ideNotResponding(): Boolean {
+        return confirm(
+            message = "The workspace IDE is not responding properly.\n" +
+                    "Would you like to try restarting the Pod or cancel the connection?",
+            title = "Cannot Connect to workspace IDE",
+            buttons = arrayOf("Cancel Connection", "Restart Pod and try again"),
+            confirmOptionIndex = 1,
+            defaultOptionIndex = 0
+        )
+    }
+
 }

--- a/src/main/resources/messages/DevSpacesBundle.properties
+++ b/src/main/resources/messages/DevSpacesBundle.properties
@@ -7,9 +7,7 @@ connector.wizard_step.openshift_connection.title=Connecting to OpenShift API ser
 connector.wizard_step.openshift_connection.label.server=Server:
 connector.wizard_step.openshift_connection.label.token=Token:
 connector.wizard_step.openshift_connection.button.previous=Back
-connector.wizard_step.openshift_connection.button.next=Check connection and continue
-connector.wizard_step.openshift_connection.label.update_kubeconfig_path=Update kubeconfig: {0}
-connector.wizard_step.openshift_connection.label.update_kubeconfig=Update kubeconfig
+connector.wizard_step.openshift_connection.button.next=Check connection
 
 # Wizard selecting DevWorkspace step
 connector.wizard_step.remote_server_connection.title=Select running DevWorkspace
@@ -21,4 +19,4 @@ connector.wizard_step.remote_server_connection.button.refresh=Refresh
 connector.wizard_step.remote_server_connection.list.empty_text=There are no DevWorkspaces
 
 connector.loader.devspaces.fetching.text=Fetching DevWorkspaces...
-connector.loader.devspaces.connecting.text=Connecting to the remote server...
+connector.loader.devspaces.connecting.text=Connecting to the Remote IDE...

--- a/src/test/kotlin/com/redhat/devtools/gateway/server/RemoteIDEServerTest.kt
+++ b/src/test/kotlin/com/redhat/devtools/gateway/server/RemoteIDEServerTest.kt
@@ -23,6 +23,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import java.io.IOException
 
@@ -66,7 +67,7 @@ class RemoteIDEServerTest {
     }
 
     @Test
-    fun `#waitServerReady should throw if server status has no join link`() {
+    fun `#waitServerReady should reach timeout and throw if server status has no join link`() {
         // given
         val withoutJoinLink = remoteIDEServerStatus(
             null,
@@ -87,7 +88,7 @@ class RemoteIDEServerTest {
     }
 
     @Test
-    fun `#waitServerReady should throw if server status has a join link but no projects`() {
+    fun `#waitServerReady should NOT reach timeout and throw if server status has a join link but no projects`() {
         // given
         val withoutProjects = remoteIDEServerStatus(
             "https://starwars.galaxy?peridea",
@@ -98,7 +99,7 @@ class RemoteIDEServerTest {
         } returns withoutProjects
 
         // when, then
-        assertThrows<IOException> {
+        assertDoesNotThrow {
             runBlocking {
                 remoteIDEServer.waitServerReady(timeout = 1)
             }
@@ -128,7 +129,7 @@ class RemoteIDEServerTest {
     }
 
     @Test
-    fun `#waitServerTerminated should return true if server status has a join link but no projects`() {
+    fun `#waitServerTerminated should return false if server status has a join link but no projects`() {
         // given
         val withoutProjects = remoteIDEServerStatus(
             "https://starwars.galaxy?peridea",
@@ -144,7 +145,7 @@ class RemoteIDEServerTest {
         }
 
         // then
-        assertThat(result).isTrue
+        assertThat(result).isFalse
     }
 
     @Test


### PR DESCRIPTION
partially fixes https://redhat.atlassian.net/browse/CRW-10683
fixes https://github.com/eclipse-che/che/issues/23812

Allows users to connect to remote IDEs which dont have a project, making it more lenient.

The portion that is fixing the root cause for the IDE to not have the project, is fixed in https://github.com/che-incubator/jetbrains-ide-dev-server/pull/88