### PR TITLE
fix: double click listener fires twice

### DIFF
--- a/src/main/kotlin/com/redhat/devtools/gateway/view/ui/SwingUtils.kt
+++ b/src/main/kotlin/com/redhat/devtools/gateway/view/ui/SwingUtils.kt
@@ -13,8 +13,8 @@ package com.redhat.devtools.gateway.view.ui
 
 import com.intellij.openapi.application.invokeLater
 import com.intellij.ui.AncestorListenerAdapter
+import com.intellij.ui.DoubleClickListener
 import com.redhat.devtools.gateway.openshift.Cluster
-import java.awt.event.MouseAdapter
 import java.awt.event.MouseEvent
 import javax.swing.JComboBox
 import javax.swing.JList
@@ -22,13 +22,12 @@ import javax.swing.JPanel
 import javax.swing.event.AncestorEvent
 
 fun <T> JList<T>.onDoubleClick(action: (T) -> Unit) {
-    addMouseListener(object : MouseAdapter() {
-        override fun mouseClicked(e: MouseEvent) {
-            if (e.clickCount == 2) {
-                selectedValue?.let { action(it) }
-            }
+    object : DoubleClickListener() {
+        override fun onDoubleClick(e: MouseEvent): Boolean {
+            selectedValue?.let { action(it) }
+            return true
         }
-    })
+    }.installOn(this)
 }
 
 fun JPanel.requestInitialFocus(component: JComboBox<Cluster>) {


### PR DESCRIPTION
**Steps:**
1. ASSERT: have at least 1 running workspace
2. EXEC: in gateway wizard, connect to cluster get to the list of workspaces, double click a running workspace
3. ASSERT: IDE for workspace is opened

**Result:**
This wont always happen, but it happens frequently (for me on MacOS):
In the gateway app, a dialog appears, telling you that the connection to the workspace was refused. As if a 2nd double click was triggered.