### PR TITLE
fix: dont error saving kubeconf if has no preferences (#23839)

### DIFF
--- a/src/main/kotlin/com/redhat/devtools/gateway/kubeconfig/KubeConfigUpdate.kt
+++ b/src/main/kotlin/com/redhat/devtools/gateway/kubeconfig/KubeConfigUpdate.kt
@@ -43,7 +43,7 @@ abstract class KubeConfigUpdate private constructor(
         contexts: ArrayList<Any?>?,
         clusters: ArrayList<Any?>?,
         users: ArrayList<Any?>?,
-        preferences: Any,
+        preferences: Any?,
         currentContext: String?,
         path: Path?
     ) {

--- a/src/test/kotlin/com/redhat/devtools/gateway/kubeconfig/KubeConfigUpdateTest.kt
+++ b/src/test/kotlin/com/redhat/devtools/gateway/kubeconfig/KubeConfigUpdateTest.kt
@@ -436,6 +436,61 @@ class KubeConfigUpdateTest {
         }
     }
 
+    @Test
+    fun `#apply works when preferences are null`() {
+        // given
+        val data = CreateContextTestData()
+        val config = KubeConfigTestHelpers.createMockKubeConfig(tempKubeConfigFile)
+        every { config.preferences } returns null
+        
+        val allConfigs = listOf(config)
+        setupCreateContextMocks(data.clusterName, allConfigs, tempKubeConfigFile)
+
+        val update = KubeConfigUpdate.CreateContext(data.clusterName, data.clusterUrl, data.token, allConfigs)
+        
+        // when
+        update.apply()
+        
+        // then
+        verify {
+            anyConstructed<BlockStyleFilePersister>().save(
+                any(),
+                any(),
+                any(),
+                null,
+                any(),
+            )
+        }
+    }
+
+    @Test
+    fun `#apply updates token when preferences are null`() {
+        // given
+        val data = UpdateTokenTestData()
+        val (existingUserMap, existingClusterMap, existingContextMap) = createUpdateTokenTestMaps(data)
+        val config = KubeConfigTestHelpers.createMockKubeConfig(tempKubeConfigFile, existingUserMap, existingClusterMap, existingContextMap)
+        every { config.preferences } returns null
+        
+        val allConfigs = listOf(config)
+        val mockContext = setupUpdateTokenMocks(data, allConfigs, config, null)
+
+        val update = KubeConfigUpdate.UpdateToken(data.clusterName, data.clusterUrl, data.newToken, mockContext, allConfigs)
+
+        // when
+        update.apply()
+
+        // then
+        verify {
+            anyConstructed<BlockStyleFilePersister>().save(
+                any(),
+                any(),
+                any(),
+                null,
+                any()
+            )
+        }
+    }
+
     private data class UpdateTokenTestData(
         val oldToken: String = "use-the-force",
         val newToken: String = "may-the-force-be-with-you",


### PR DESCRIPTION
fixes https://github.com/eclipse-che/che/issues/23839