### PR TITLE
fix: dont consume ssl cert input stream when cloning api-client (#23842)

### DIFF
--- a/src/main/kotlin/com/redhat/devtools/gateway/DevSpacesContext.kt
+++ b/src/main/kotlin/com/redhat/devtools/gateway/DevSpacesContext.kt
@@ -14,12 +14,10 @@ package com.redhat.devtools.gateway
 import com.redhat.devtools.gateway.devworkspace.DevWorkspace
 import io.kubernetes.client.openapi.ApiClient
 
-class DevSpacesContext() {
+class DevSpacesContext {
     lateinit var client: ApiClient
     lateinit var devWorkspace: DevWorkspace
     var activeWorkspaces = mutableSetOf<DevWorkspace>()
-
-    fun isClientInitialized(): Boolean = ::client.isInitialized
 
     fun addWorkspace(workspace: DevWorkspace) {
         synchronized(activeWorkspaces) {

--- a/src/main/kotlin/com/redhat/devtools/gateway/openshift/ApiClientUtils.kt
+++ b/src/main/kotlin/com/redhat/devtools/gateway/openshift/ApiClientUtils.kt
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2024-2026 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package com.redhat.devtools.gateway.openshift
+
+import com.intellij.openapi.diagnostic.thisLogger
+import io.kubernetes.client.openapi.ApiClient
+import io.kubernetes.client.openapi.auth.ApiKeyAuth
+import io.kubernetes.client.openapi.auth.HttpBasicAuth
+import io.kubernetes.client.openapi.auth.HttpBearerAuth
+import okhttp3.OkHttpClient
+import java.util.concurrent.TimeUnit
+
+/**
+ * Helpers for building [ApiClient] instances used by OpenShift / Kubernetes integration.
+ */
+object ApiClientUtils {
+
+    /**
+     * Clone [base] for pod exec: fork TLS from [base]'s OkHttpClient, new dispatcher/pool/ping, then
+     * isolate exec traffic on a fresh pool/dispatcher. Do not call [ApiClient.setSslCaCert] here—the
+     * CA stream is single-use ([ApiClient.applySslSettings] consumes it). Internal for tests.
+     */
+    internal fun cloneForExec(base: ApiClient): ApiClient {
+        val newHttp = cloneHttpClient(base.httpClient, zeroPingForExec = true)
+        return ApiClient(newHttp).apply {
+            basePath = base.basePath
+            setDebugging(base.isDebugging)
+            /*
+             * Do not call:
+             * - setVerifyingSsl
+             * - setSslCaCert
+             * - setKeyManagers
+             * Each triggers ApiClient.applySslSettings(), which reads sslCaCert to EOF.
+             * The kube client keeps a single shared InputStream. A second read yields no certs and throws
+             * IllegalArgumentException("expected non-empty set of trusted certificates").
+             * newHttp is forked from base.httpClient and already carries the correct TLS stack.
+             */
+            setReadTimeout(base.readTimeout)
+            setConnectTimeout(base.connectTimeout)
+            setWriteTimeout(base.writeTimeout)
+
+            copyAuthentications(base, this)
+
+            readDefaultHeaderMap(base).forEach { (k, v) -> addDefaultHeader(k, v) }
+            readDefaultCookieMap(base).forEach { (k, v) -> addDefaultCookie(k, v) }
+        }
+    }
+
+    private fun copyAuthentications(source: ApiClient, target: ApiClient) {
+        source.authentications.forEach { (name, auth) ->
+            val dest = target.getAuthentication(name) ?: return@forEach
+            when (auth) {
+                is ApiKeyAuth -> {
+                    if (dest is ApiKeyAuth) {
+                        dest.apiKey = auth.apiKey
+                        dest.apiKeyPrefix = auth.apiKeyPrefix
+                    }
+                }
+
+                is HttpBasicAuth -> {
+                    if (dest is HttpBasicAuth) {
+                        dest.username = auth.username
+                        dest.password = auth.password
+                    }
+                }
+
+                is HttpBearerAuth -> {
+                    if (dest is HttpBearerAuth) {
+                        // No access to private "scheme" – always use correct "Bearer"
+                        dest.bearerToken = auth.bearerToken
+                    }
+                }
+            }
+        }
+    }
+
+    private fun readDefaultHeaderMap(client: ApiClient): Map<String, String> =
+        readPrivateMap(client, "defaultHeaderMap")
+
+    private fun readDefaultCookieMap(client: ApiClient): Map<String, String> =
+        readPrivateMap(client, "defaultCookieMap")
+
+    private fun readPrivateMap(client: ApiClient, fieldName: String): Map<String, String> =
+        try {
+            val field = ApiClient::class.java.getDeclaredField(fieldName)
+            field.isAccessible = true
+            @Suppress("UNCHECKED_CAST")
+            (field.get(client) as? Map<String, String>) ?: emptyMap()
+        } catch (e: Exception) {
+            thisLogger<ApiClientUtils>().warn(
+                "Could not read ApiClient.$fieldName via reflection; cloned exec client will omit these entries.",
+                e
+            )
+            emptyMap()
+        }
+
+    /**
+     * Forks [source] with a fresh [okhttp3.ConnectionPool] and [okhttp3.Dispatcher] (same max request
+     * limits as the original dispatcher). When [zeroPingForExec] is true, WebSocket ping is disabled
+     * for Kubernetes exec; otherwise ping settings are left as inherited from [source].
+     */
+    private fun cloneHttpClient(source: OkHttpClient, zeroPingForExec: Boolean): OkHttpClient {
+        val originalDispatcher = source.dispatcher
+        val newDispatcher = okhttp3.Dispatcher().apply {
+            maxRequests = originalDispatcher.maxRequests
+            maxRequestsPerHost = originalDispatcher.maxRequestsPerHost
+        }
+        val builder = source.newBuilder()
+            .dispatcher(newDispatcher)
+            .connectionPool(okhttp3.ConnectionPool())
+        if (zeroPingForExec) {
+            builder.pingInterval(0, TimeUnit.SECONDS) // IMPORTANT for Exec
+        }
+        return builder.build()
+    }
+
+}

--- a/src/main/kotlin/com/redhat/devtools/gateway/openshift/DevWorkspacePods.kt
+++ b/src/main/kotlin/com/redhat/devtools/gateway/openshift/DevWorkspacePods.kt
@@ -17,9 +17,6 @@ import io.kubernetes.client.PortForward
 import io.kubernetes.client.openapi.ApiClient
 import io.kubernetes.client.openapi.ApiException
 import io.kubernetes.client.openapi.apis.CoreV1Api
-import io.kubernetes.client.openapi.auth.ApiKeyAuth
-import io.kubernetes.client.openapi.auth.HttpBasicAuth
-import io.kubernetes.client.openapi.auth.HttpBearerAuth
 import io.kubernetes.client.openapi.models.V1Pod
 import io.kubernetes.client.openapi.models.V1PodList
 import kotlinx.coroutines.*
@@ -134,100 +131,8 @@ class DevWorkspacePods(private val client: ApiClient) {
         }
     }
 
-    // Helpers to access private maps using reflection
-     private fun ApiClient.copy(): ApiClient {
-        val originalDispatcher = this.httpClient.dispatcher
-        val newDispatcher = okhttp3.Dispatcher().apply {
-            maxRequests = originalDispatcher.maxRequests
-            maxRequestsPerHost = originalDispatcher.maxRequestsPerHost
-        }
-        val newPool = okhttp3.ConnectionPool()
-
-        val newHttp = this.httpClient.newBuilder()
-            .dispatcher(newDispatcher)
-            .connectionPool(newPool)
-            .pingInterval(0, java.util.concurrent.TimeUnit.SECONDS) // IMPORTANT for Exec
-            .build()
-
-        val clone = ApiClient(newHttp)
-
-        clone.basePath = this.basePath
-        clone.setDebugging(this.isDebugging)
-        clone.setVerifyingSsl(this.isVerifyingSsl)
-        clone.setSslCaCert(this.sslCaCert)
-        clone.setKeyManagers(this.keyManagers)
-        clone.setReadTimeout(this.readTimeout)
-        clone.setConnectTimeout(this.connectTimeout)
-        clone.setWriteTimeout(this.writeTimeout)
-
-        this.authentications.forEach { (name, auth) ->
-            val target = clone.getAuthentication(name) ?: return@forEach
-
-            when (auth) {
-                is ApiKeyAuth -> {
-                    if (target is ApiKeyAuth) {
-                        target.apiKey = auth.apiKey
-                        target.apiKeyPrefix = auth.apiKeyPrefix
-                    }
-                }
-
-                is HttpBasicAuth -> {
-                    if (target is HttpBasicAuth) {
-                        target.username = auth.username
-                        target.password = auth.password
-                    }
-                }
-
-                is HttpBearerAuth -> {
-                    if (target is HttpBearerAuth) {
-                        // No access to private "scheme" – always use correct "Bearer"
-                        target.bearerToken = auth.bearerToken
-                    }
-                }
-            }
-        }
-
-        defaultHeaders().forEach { (k, v) -> clone.addDefaultHeader(k, v) }
-        defaultCookies().forEach { (k, v) -> clone.addDefaultCookie(k, v) }
-        return clone
-    }
-
-    // Helpers to access headers/cookies via public API
-    fun ApiClient.defaultHeaders(): Map<String, String> {
-        return try {
-            val field = ApiClient::class.java.getDeclaredField("defaultHeaderMap")
-            field.isAccessible = true
-            @Suppress("UNCHECKED_CAST")
-            field.get(this) as Map<String, String>
-        } catch (_: Exception) {
-            emptyMap()
-        }
-    }
-
-    fun ApiClient.defaultCookies(): Map<String, String> {
-        return try {
-            val field = ApiClient::class.java.getDeclaredField("defaultCookieMap")
-            field.isAccessible = true
-            @Suppress("UNCHECKED_CAST")
-            field.get(this) as Map<String, String>
-        } catch (_: Exception) {
-            emptyMap()
-        }
-    }
-
-    private fun createIsolatedExecClient(base: ApiClient): ApiClient {
-        val cloned = base.copy()
-
-        val originalDispatcher = base.httpClient.dispatcher
-        cloned.httpClient = base.httpClient.newBuilder()
-            .connectionPool(okhttp3.ConnectionPool()) // Still need new pool for isolation
-            .dispatcher(okhttp3.Dispatcher().apply {
-                maxRequests = originalDispatcher.maxRequests
-                maxRequestsPerHost = originalDispatcher.maxRequestsPerHost
-            })
-            .build()
-        return cloned
-    }
+    private fun createIsolatedExecClient(base: ApiClient): ApiClient =
+        ApiClientUtils.cloneForExec(base)
 
     @Throws(IOException::class)
     fun forward(pod: V1Pod, localPort: Int, remotePort: Int): Closeable {

--- a/src/test/kotlin/com/redhat/devtools/gateway/openshift/ApiClientUtilsTest.kt
+++ b/src/test/kotlin/com/redhat/devtools/gateway/openshift/ApiClientUtilsTest.kt
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2026 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package com.redhat.devtools.gateway.openshift
+
+import io.kubernetes.client.openapi.ApiClient
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.io.ByteArrayInputStream
+import java.nio.charset.StandardCharsets
+
+/**
+ * [ApiClientUtils.cloneForExec] must not re-read [ApiClient.sslCaCert]: the Kubernetes client keeps a
+ * single-use stream; [ApiClient.setSslCaCert] triggers [applySslSettings] which consumes it.
+ * Exec cloning forks OkHttp from the parent and must not call those setters again.
+ */
+class ApiClientUtilsTest {
+
+    /** Self-signed RSA fixture for this test only (*.invalid); not from any cluster or public CA. */
+    // notsecret
+    private val testCaPem = """
+        -----BEGIN CERTIFICATE-----
+        MIIDlTCCAn2gAwIBAgIUJ/MyNwdZC5vGYJMyYa5m4letZrYwDQYJKoZIhvcNAQEL
+        BQAwWjEnMCUGA1UEAwweZmFrZS11bml0LXRlc3QuZXhhbXBsZS5pbnZhbGlkMSIw
+        IAYDVQQKDBlFeGFtcGxlIFRlc3QgRml4dHVyZSBPbmx5MQswCQYDVQQGEwJYWDAe
+        Fw0yNjA1MTMxMzE4MDJaFw0zNjA1MTAxMzE4MDJaMFoxJzAlBgNVBAMMHmZha2Ut
+        dW5pdC10ZXN0LmV4YW1wbGUuaW52YWxpZDEiMCAGA1UECgwZRXhhbXBsZSBUZXN0
+        IEZpeHR1cmUgT25seTELMAkGA1UEBhMCWFgwggEiMA0GCSqGSIb3DQEBAQUAA4IB
+        DwAwggEKAoIBAQCG4CRbIkDOtpWzjWVW3V62FKzSfdAhdOJ/avqaPU2FiSjwEcBu
+        VceoT5ilVjNWuDSqWeTrmwPjBfzywpB9OHrziqE5rRBnlyuxTMgxxbpNU8WEBFtn
+        2RWvKen0uZOOLTro1oQsI6ALqKd07s8t9XjIZMEiOzhvKzYK6xQiqXjnYJqWAw3Z
+        jhuvPcuvAALTXJMB6dASZNJ+q7gUd0gIMIjXVzAcj/QPxISwr3JMbpk+GvDnz0kF
+        t7TFQRMqW56dbK36ukjDvLdFd+bbigE6m55vsGVdyZC55wBIB87ycn0zc3hgrfej
+        4JVEqEhhlsifUkjGqNR2h9cdY3u58gzJwZP5AgMBAAGjUzBRMB0GA1UdDgQWBBSn
+        488Oxr0rTEaI1Q3xHhxERrAZ5jAfBgNVHSMEGDAWgBSn488Oxr0rTEaI1Q3xHhxE
+        RrAZ5jAPBgNVHRMBAf8EBTADAQH/MA0GCSqGSIb3DQEBCwUAA4IBAQAu0fWReMMg
+        SMM2ctyslZ/b00FDUnDq713HQ+HH3sB28NVxvwKUHR637Z/VzX2HNlR5wuR2ulxK
+        i6m54EBVCuE+T4kwPD/wx32RtGMAyuBlpamLC6WOdmVIVdYr66BRE7KdfTNnK+MJ
+        Aa0duD5KniqxkdMU7ZxveHM6RRv/hDg0qybOxLSwetmfI9CRiw0qOGiX5PhCqsJV
+        If1FxRl2mPPO0HiI94AyenmZfatuz9Y8Pb/q7cgdXpX2x29dnqXXO91qbVHk+zII
+        sYowqsdnMTfqNHFSJGrNovvI63/GQ/8148oKAALaH4VgNOyVIdaKkPDR5I/WBnNm
+        gJHFa/ozYnVi
+        -----END CERTIFICATE-----
+    """.trimIndent()
+
+    @Test
+    fun `cloneForExec succeeds when sslCaCert stream is already consumed`() {
+        // given
+        val caStream = ByteArrayInputStream(testCaPem.toByteArray(StandardCharsets.UTF_8))
+        val client = ApiClient()
+        client.basePath = "https://127.0.0.1:6443"
+        client.setVerifyingSsl(true)
+        client.setSslCaCert(caStream)
+
+        assertThat(caStream.read())
+            .describedAs("CA stream must be exhausted after first setSslCaCert / applySslSettings")
+            .isEqualTo(-1)
+        // when
+        val execClient = ApiClientUtils.cloneForExec(client)
+        // then
+        assertThat(execClient).isNotNull
+        assertThat(execClient.httpClient.sslSocketFactory)
+            .isSameAs(client.httpClient.sslSocketFactory)
+    }
+}

--- a/src/test/kotlin/com/redhat/devtools/gateway/openshift/DevWorkspacePodsTest.kt
+++ b/src/test/kotlin/com/redhat/devtools/gateway/openshift/DevWorkspacePodsTest.kt
@@ -38,6 +38,7 @@ import java.io.ByteArrayOutputStream
 import java.io.IOException
 import java.net.ServerSocket
 import java.net.Socket
+import kotlin.time.Duration.Companion.milliseconds
 
 class DevWorkspacePodsTest {
 
@@ -92,14 +93,12 @@ class DevWorkspacePodsTest {
 
         // then
         // wait for the server to start
-        runBlocking { delay(100) }
+        runBlocking { delay(100.milliseconds) }
 
-        try {
+        closeable.use { closeable ->
             // Verify that data from server input stream is received by client
             val bytesRead = sendClientData("ping") // Send data to trigger server response
             assertThat(String(buffer, 0, bytesRead)).isEqualTo(serverData)
-        } finally {
-            closeable.close()
         }
     }
 
@@ -115,18 +114,16 @@ class DevWorkspacePodsTest {
 
         // then
         // wait for the server to start
-        runBlocking { delay(100) }
+        runBlocking { delay(100.milliseconds) }
         Socket("127.0.0.1", localPort).apply {
             close() // trigger retry
         }
-        runBlocking { delay(6000) } // 5 attempts * 1 second
+        runBlocking { delay(6000.milliseconds) } // 5 attempts * 1 second
 
-        try {
+        closeable.use { closeable ->
             verify(atLeast = 2) { // 2+ retries
                 anyConstructed<PortForward>().forward(pod, listOf(remotePort))
             }
-        } finally {
-            closeable.close()
         }
     }
 


### PR DESCRIPTION
fixes https://github.com/eclipse-che/che/issues/23842