### PR TITLE
Add download link on PRs for easier testing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,13 +89,6 @@ jobs:
           name: ${{ steps.artifact.outputs.filename }}
           path: ./build/distributions/content/*/*
 
-      # Store plugin zip for easy download
-      - name: Upload plugin zip
-        uses: actions/upload-artifact@v7
-        with:
-          name: ${{ steps.artifact.outputs.filename }}-zip
-          path: ./build/distributions/*.zip
-
   # Run tests and upload a code coverage report
   test:
     name: Test
@@ -238,7 +231,7 @@ jobs:
         run: |
           gh pr comment ${{ github.event.pull_request.number }} \
             --repo ${{ github.repository }} \
-            --body "✅ Build successful! [Download plugin zip](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) from the Artifacts section."
+            --body "✅ Build successful! For testing, [download plugin zip](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) from the Artifacts section."
 
   # Prepare a draft release for GitHub Releases page for the manual verification
   # If accepted and published, release workflow would be triggered

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,6 +89,13 @@ jobs:
           name: ${{ steps.artifact.outputs.filename }}
           path: ./build/distributions/content/*/*
 
+      # Store plugin zip for easy download
+      - name: Upload plugin zip
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ steps.artifact.outputs.filename }}-zip
+          path: ./build/distributions/*.zip
+
   # Run tests and upload a code coverage report
   test:
     name: Test
@@ -215,6 +222,23 @@ jobs:
         with:
           name: pluginVerifier-result
           path: ${{ github.workspace }}/build/reports/pluginVerifier
+
+  # Post a comment on PRs with a link to download the plugin
+  prComment:
+    name: PR comment
+    if: github.event_name == 'pull_request'
+    needs: [ build, test, inspectCode, verify ]
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Post artifact link
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr comment ${{ github.event.pull_request.number }} \
+            --repo ${{ github.repository }} \
+            --body "✅ Build successful! [Download plugin zip](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) from the Artifacts section."
 
   # Prepare a draft release for GitHub Releases page for the manual verification
   # If accepted and published, release workflow would be triggered


### PR DESCRIPTION
Once the PR checks are green, the comment appears on the PR with the link to download the built artifact:

<img width="886" height="163" alt="image" src="https://github.com/user-attachments/assets/c183c389-0bcf-4ccb-b360-ea534cc240e9" />


<img width="1363" height="281" alt="image" src="https://github.com/user-attachments/assets/deaaf8f4-de01-4bd6-a233-beceade16d56" />
