### PR TITLE
Fix OpenShift OAuth flow with EntraId on OCP 4.18 and Gateway connection hangs

### DIFF
--- a/build.local.gradle.kts
+++ b/build.local.gradle.kts
@@ -1,0 +1,75 @@
+import org.gradle.api.tasks.Copy
+import org.gradle.language.jvm.tasks.ProcessResources
+
+plugins {
+    kotlin("jvm") version "2.3.21"
+    kotlin("plugin.serialization") version "2.3.21"
+}
+
+group = "com.redhat.devtools.gateway"
+version = providers.gradleProperty("pluginVersion").get()
+
+repositories {
+    mavenCentral()
+}
+
+val gatewayHome = file(
+    providers.gradleProperty("gatewayHome")
+        .orElse(providers.environmentVariable("GATEWAY_HOME"))
+        .getOrElse("${System.getProperty("user.home")}/AppData/Local/Programs/Gateway")
+)
+
+dependencies {
+    compileOnly(fileTree(gatewayHome.resolve("lib")) { include("*.jar") })
+    compileOnly(fileTree(gatewayHome.resolve("plugins")) { include("**/*.jar") })
+
+    implementation("io.kubernetes:client-java:24.0.0")
+    implementation("com.fasterxml.jackson.core:jackson-databind:2.21.3")
+    implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.21.3")
+    implementation("com.nimbusds:oauth2-oidc-sdk:11.15")
+    implementation("com.nimbusds:nimbus-jose-jwt:10.9")
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.8.1")
+}
+
+kotlin {
+    jvmToolchain(17)
+}
+
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
+    compilerOptions {
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
+        freeCompilerArgs.add("-Xjvm-default=all")
+    }
+}
+
+tasks.withType<Jar>().configureEach {
+    archiveBaseName.set("devspaces-gateway-plugin")
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+}
+
+tasks.withType<ProcessResources>().configureEach {
+    inputs.property("pluginVersion", project.version.toString())
+    filesMatching("META-INF/plugin.xml") {
+        expand("pluginVersion" to project.version.toString())
+    }
+}
+
+val localPluginDir = layout.buildDirectory.dir("localPlugin/devspaces-gateway-plugin")
+
+val assembleLocalPlugin by tasks.registering(Copy::class) {
+    dependsOn(tasks.jar)
+    into(localPluginDir)
+    into("lib") {
+        from(tasks.jar)
+        from(configurations.runtimeClasspath)
+    }
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+}
+
+tasks.register<Zip>("buildLocalPlugin") {
+    dependsOn(assembleLocalPlugin)
+    archiveFileName.set("devspaces-gateway-plugin-${project.version}.zip")
+    destinationDirectory.set(layout.buildDirectory.dir("distributions"))
+    from(layout.buildDirectory.dir("localPlugin"))
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+}

--- a/ccp-build.sh
+++ b/ccp-build.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+gradle \
+  -b "$SCRIPT_DIR/build.local.gradle.kts" \
+  buildLocalPlugin \
+  --no-daemon \
+  --no-configuration-cache \
+  --no-build-cache \
+  "-Dorg.gradle.configuration-cache=false" \
+  "-Dorg.gradle.caching=false"
+
+PLUGIN_VERSION="$(grep -E '^pluginVersion[[:space:]]*=' "$SCRIPT_DIR/gradle.properties" | sed -E 's/^[^=]+=[[:space:]]*//')"
+echo "Built: $SCRIPT_DIR/build/distributions/devspaces-gateway-plugin-${PLUGIN_VERSION}.zip"

--- a/ccp-install.ps1
+++ b/ccp-install.ps1
@@ -1,0 +1,71 @@
+param(
+    [string]$GatewayPluginsPath,
+    [switch]$RemoveBackups
+)
+
+$ErrorActionPreference = "Stop"
+
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$GradleProperties = Join-Path $ScriptDir "gradle.properties"
+
+if (-not (Test-Path -LiteralPath $GradleProperties)) {
+    throw "gradle.properties not found: $GradleProperties"
+}
+
+$PluginVersion = Select-String -LiteralPath $GradleProperties -Pattern '^pluginVersion\s*=\s*(.+)$' |
+    ForEach-Object { $_.Matches[0].Groups[1].Value.Trim() } |
+    Select-Object -First 1
+
+if ([string]::IsNullOrWhiteSpace($PluginVersion)) {
+    throw "pluginVersion not found in $GradleProperties"
+}
+
+$PluginZip = Join-Path $ScriptDir "build\distributions\devspaces-gateway-plugin-$PluginVersion.zip"
+
+if (-not (Test-Path -LiteralPath $PluginZip)) {
+    throw "Plugin ZIP not found: $PluginZip. Run ccp-build.sh first."
+}
+
+if ([string]::IsNullOrWhiteSpace($GatewayPluginsPath)) {
+    $JetBrainsConfigPath = Join-Path $env:APPDATA "JetBrains"
+    if (-not (Test-Path -LiteralPath $JetBrainsConfigPath)) {
+        throw "JetBrains config directory not found: $JetBrainsConfigPath"
+    }
+
+    $LatestGatewayConfig = Get-ChildItem -LiteralPath $JetBrainsConfigPath -Directory -Filter "JetBrainsGateway*" |
+        Sort-Object LastWriteTime -Descending |
+        Select-Object -First 1
+
+    if ($null -eq $LatestGatewayConfig) {
+        throw "No JetBrainsGateway* config directory found in: $JetBrainsConfigPath"
+    }
+
+    $GatewayPluginsPath = Join-Path $LatestGatewayConfig.FullName "plugins"
+    Write-Host "Using latest Gateway config: $($LatestGatewayConfig.FullName)"
+}
+
+if (-not (Test-Path -LiteralPath $GatewayPluginsPath)) {
+    throw "Gateway plugins directory not found: $GatewayPluginsPath"
+}
+
+$OldPlugins = if ($RemoveBackups) {
+    Get-ChildItem -LiteralPath $GatewayPluginsPath -Directory -Filter "devspaces-gateway-plugin*"
+} else {
+    Get-Item -LiteralPath (Join-Path $GatewayPluginsPath "devspaces-gateway-plugin") -ErrorAction SilentlyContinue
+}
+
+foreach ($OldPlugin in $OldPlugins) {
+    Remove-Item -LiteralPath $OldPlugin.FullName -Recurse -Force
+    Write-Host "Removed: $($OldPlugin.FullName)"
+}
+
+Expand-Archive -LiteralPath $PluginZip -DestinationPath $GatewayPluginsPath -Force
+
+$InstalledPlugin = Join-Path $GatewayPluginsPath "devspaces-gateway-plugin"
+if (-not (Test-Path -LiteralPath $InstalledPlugin)) {
+    throw "Plugin was not installed as expected: $InstalledPlugin"
+}
+
+Write-Host "Installed: $PluginZip"
+Write-Host "To:        $InstalledPlugin"
+Write-Host "Restart JetBrains Gateway to load the plugin."

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,5 +1,8 @@
-plugins {
-    id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
+pluginManagement {
+    repositories {
+        mavenCentral()
+        gradlePluginPortal()
+    }
 }
 
 rootProject.name = "devspaces-gateway-plugin"

--- a/src/main/kotlin/com/redhat/devtools/gateway/DevSpacesConnectionProvider.kt
+++ b/src/main/kotlin/com/redhat/devtools/gateway/DevSpacesConnectionProvider.kt
@@ -37,6 +37,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
 import java.util.concurrent.CancellationException
 import javax.swing.JComponent
 import javax.swing.Timer
@@ -80,6 +81,14 @@ class DevSpacesConnectionProvider : GatewayConnectionProvider {
                         val thinClient = handle.clientHandle
                             ?: throw RuntimeException("Failed to obtain ThinClientHandle")
 
+                        if (thinClient.clientPresent) {
+                            indicator.text = "Workspace IDE has started successfully"
+                            indicator.text2 = "Opening project window..."
+                            runDelayed(1000) { if (indicator.isRunning) indicator.stop() }
+                            cont.resume(handle)
+                            return@runProcessWithProgressSynchronously
+                        }
+
                         indicator.text = "Waiting for workspace IDE to start..."
 
                         val ready = CompletableDeferred<GatewayConnectionHandle?>()
@@ -98,6 +107,17 @@ class DevSpacesConnectionProvider : GatewayConnectionProvider {
                                 cont.resume(ready.getCompleted())
                             } else {
                                 cont.resumeWith(Result.failure(error))
+                            }
+                        }
+
+                        runBlocking {
+                            withTimeoutOrNull(60_000L) { ready.await() } ?: run {
+                                if (ready.isActive) {
+                                    indicator.text = "Workspace IDE did not report readiness in time."
+                                    ready.completeExceptionally(
+                                        RuntimeException("Workspace IDE did not report readiness in time.")
+                                    )
+                                }
                             }
                         }
                     } catch (e: ApiException) {

--- a/src/main/kotlin/com/redhat/devtools/gateway/auth/tls/SslContextFactory.kt
+++ b/src/main/kotlin/com/redhat/devtools/gateway/auth/tls/SslContextFactory.kt
@@ -12,6 +12,7 @@
 package com.redhat.devtools.gateway.auth.tls
 
 import java.security.SecureRandom
+import java.security.cert.CertificateException
 import java.security.cert.X509Certificate
 import javax.net.ssl.SSLContext
 import javax.net.ssl.TrustManager
@@ -40,6 +41,15 @@ object SslContextFactory {
     }
 
     fun fromTrustedCerts(certs: List<X509Certificate>): TlsContext {
+        val defaultTrustManager = defaultTrustManager()
+        if (certs.isEmpty()) {
+            val sslContext = SSLContext.getInstance(SSL_PROTOCOL).apply {
+                init(null, arrayOf<TrustManager>(defaultTrustManager), SecureRandom())
+            }
+
+            return TlsContext(sslContext, defaultTrustManager)
+        }
+
         val keyStore = KeyStoreUtils.createEmpty()
 
         certs.forEachIndexed { idx, cert ->
@@ -55,12 +65,17 @@ object SslContextFactory {
         )
         tmf.init(keyStore)
 
-        val trustManager = tmf.trustManagers
+        val customTrustManager = tmf.trustManagers
             .filterIsInstance<X509TrustManager>()
             .first()
 
+        val trustManager = CompositeX509TrustManager(
+            defaultTrustManager,
+            customTrustManager
+        )
+
         val sslContext = SSLContext.getInstance(SSL_PROTOCOL).apply {
-            init(null, tmf.trustManagers, SecureRandom())
+            init(null, arrayOf<TrustManager>(trustManager), SecureRandom())
         }
 
         return TlsContext(sslContext, trustManager)
@@ -80,4 +95,50 @@ object SslContextFactory {
         return TlsContext(sslContext, capturingTrustManager)
     }
 
+}
+
+private fun defaultTrustManager(): X509TrustManager {
+    val tmf = TrustManagerFactory.getInstance(
+        TrustManagerFactory.getDefaultAlgorithm()
+    )
+    tmf.init(null as java.security.KeyStore?)
+
+    return tmf.trustManagers
+        .filterIsInstance<X509TrustManager>()
+        .first()
+}
+
+private class CompositeX509TrustManager(
+    private val defaultTrustManager: X509TrustManager,
+    private val customTrustManager: X509TrustManager
+) : X509TrustManager {
+
+    override fun checkClientTrusted(chain: Array<X509Certificate>, authType: String) {
+        checkTrusted(
+            { defaultTrustManager.checkClientTrusted(chain, authType) },
+            { customTrustManager.checkClientTrusted(chain, authType) }
+        )
+    }
+
+    override fun checkServerTrusted(chain: Array<X509Certificate>, authType: String) {
+        checkTrusted(
+            { defaultTrustManager.checkServerTrusted(chain, authType) },
+            { customTrustManager.checkServerTrusted(chain, authType) }
+        )
+    }
+
+    override fun getAcceptedIssuers(): Array<X509Certificate> =
+        defaultTrustManager.acceptedIssuers + customTrustManager.acceptedIssuers
+
+    private fun checkTrusted(defaultCheck: () -> Unit, customCheck: () -> Unit) {
+        try {
+            defaultCheck()
+        } catch (defaultFailure: CertificateException) {
+            try {
+                customCheck()
+            } catch (_: CertificateException) {
+                throw defaultFailure
+            }
+        }
+    }
 }

--- a/src/main/kotlin/com/redhat/devtools/gateway/openshift/OpenShiftClientFactory.kt
+++ b/src/main/kotlin/com/redhat/devtools/gateway/openshift/OpenShiftClientFactory.kt
@@ -122,6 +122,7 @@ class OpenShiftClientFactory(private val configUtils: KubeConfigUtils) {
         val sslContext = createSSLContext(trustManager, usingClientCert, clientCert, clientKey)
         client.httpClient = client.httpClient.newBuilder()
             .sslSocketFactory(sslContext.socketFactory, trustManager)
+            .connectTimeout(15, TimeUnit.SECONDS)
             .build()
 
         return client

--- a/src/main/kotlin/com/redhat/devtools/gateway/openshift/Projects.kt
+++ b/src/main/kotlin/com/redhat/devtools/gateway/openshift/Projects.kt
@@ -15,7 +15,6 @@ import io.kubernetes.client.openapi.ApiClient
 import io.kubernetes.client.openapi.ApiException
 import io.kubernetes.client.openapi.apis.CustomObjectsApi
 
-import io.kubernetes.client.openapi.apis.CoreV1Api
 import io.kubernetes.client.openapi.apis.AuthorizationV1Api
 import io.kubernetes.client.openapi.models.V1SelfSubjectAccessReview
 import io.kubernetes.client.openapi.models.V1SelfSubjectAccessReviewSpec
@@ -46,8 +45,19 @@ class Projects(private val client: ApiClient) {
     @Throws(ApiException::class)
     fun isAuthenticated(): Boolean {
         return try {
-            CoreV1Api(client).listNamespace().execute()
-            true  // 200 OK - authenticated and authorized
+            AuthorizationV1Api(client).createSelfSubjectAccessReview(
+                V1SelfSubjectAccessReview()
+                    .spec(
+                        V1SelfSubjectAccessReviewSpec()
+                            .resourceAttributes(
+                                V1ResourceAttributes()
+                                    .group("project.openshift.io")
+                                    .resource("projects")
+                                    .verb("list")
+                            )
+                    )
+            ).execute()
+            true  // 201 Created - authenticated; access result is not relevant here
         } catch (e: ApiException) {
             when (e.code) {
                 401 -> false  // Unauthorized - not authenticated

--- a/src/main/kotlin/com/redhat/devtools/gateway/view/steps/DevSpacesServerStepView.kt
+++ b/src/main/kotlin/com/redhat/devtools/gateway/view/steps/DevSpacesServerStepView.kt
@@ -29,7 +29,6 @@ import com.intellij.util.ui.JBFont
 import com.intellij.util.ui.JBUI
 import com.redhat.devtools.gateway.DevSpacesBundle
 import com.redhat.devtools.gateway.DevSpacesContext
-import com.redhat.devtools.gateway.auth.session.RedHatAuthSessionManager
 import com.redhat.devtools.gateway.auth.tls.*
 import com.redhat.devtools.gateway.auth.tls.ui.UiTlsDecisionAdapter
 import com.redhat.devtools.gateway.kubeconfig.FileWatcher
@@ -85,10 +84,6 @@ class DevSpacesServerStepView(
     private val saveConfig: Boolean
         get() = saveConfigCheckbox.isEnabled && saveConfigCheckbox.isSelected
 
-    private val sessionManager =
-        ApplicationManager.getApplication()
-            .getService(RedHatAuthSessionManager::class.java)
-
     private var tfCertAuthority = JBTextField()
         .apply {
             document.addDocumentListener(onFieldChanged())
@@ -141,11 +136,6 @@ class DevSpacesServerStepView(
                 ::onFieldChanged,
                 ::createEnterKeyListener,
                 setTokenDisplay
-            ),
-            RedHatSSOAuthenticationStrategy(
-                tfServer,
-                ::saveKubeconfig,
-                sessionManager
             )
         )
     }
@@ -514,21 +504,22 @@ class DevSpacesServerStepView(
     private suspend fun saveKubeconfig(cluster: Cluster, token: String, indicator: ProgressIndicator) {
         if (!saveConfig || token.isBlank()) return
 
-        try {
-            indicator.text = "Updating Kube config..."
-            withContext(Dispatchers.IO) {
+        indicator.text = "Updating Kube config..."
+        val clusterName = cluster.name.trim()
+        val clusterUrl = cluster.url.trim()
+        val authToken = token.trim()
+
+        // Kubeconfig persistence is optional; do not block the connection flow on local file I/O.
+        CoroutineScope(SupervisorJob() + Dispatchers.IO).launch {
+            try {
                 KubeConfigUpdate
                     .create(
-                        cluster.name.trim(),
-                        cluster.url.trim(),
-                        token.trim())
+                        clusterName,
+                        clusterUrl,
+                        authToken)
                     .apply()
-            }
-
-        } catch (e: Exception) {
-            thisLogger().warn(e.message ?: "Could not save configuration file", e)
-            withContext(Dispatchers.Main) {
-                Dialogs.error(e.message ?: "Could not save configuration file", "Save Config Failed")
+            } catch (e: Exception) {
+                thisLogger().warn(e.message ?: "Could not save configuration file", e)
             }
         }
     }
@@ -539,21 +530,24 @@ class DevSpacesServerStepView(
             || clientKeyPem.isBlank())
             return
 
-        try {
-            indicator.text = "Updating Kube config..."
-            withContext(Dispatchers.IO) {
+        indicator.text = "Updating Kube config..."
+        val clusterName = cluster.name.trim()
+        val clusterUrl = cluster.url.trim()
+        val clientCert = clientCertPem.trim()
+        val clientKey = clientKeyPem.trim()
+
+        // Kubeconfig persistence is optional; do not block the connection flow on local file I/O.
+        CoroutineScope(SupervisorJob() + Dispatchers.IO).launch {
+            try {
                 KubeConfigUpdate
                     .create(
-                        cluster.name.trim(),
-                        cluster.url.trim(),
-                        clientCertPem.trim(),
-                        clientKeyPem.trim())
+                        clusterName,
+                        clusterUrl,
+                        clientCert,
+                        clientKey)
                     .apply()
-            }
-        } catch (e: Exception) {
-            thisLogger().warn(e.message ?: "Could not save configuration file", e)
-            withContext(Dispatchers.Main) {
-                Dialogs.error(e.message ?: "Could not save configuration file", "Save Config Failed")
+            } catch (e: Exception) {
+                thisLogger().warn(e.message ?: "Could not save configuration file", e)
             }
         }
     }

--- a/src/main/kotlin/com/redhat/devtools/gateway/view/steps/auth/OpenShiftOAuthAuthenticationStrategy.kt
+++ b/src/main/kotlin/com/redhat/devtools/gateway/view/steps/auth/OpenShiftOAuthAuthenticationStrategy.kt
@@ -71,33 +71,37 @@ class OpenShiftOAuthAuthenticationStrategy(
         currentCoroutineContext().ensureActive()
 
         coroutineScope {
-            launchCancelWatcher(indicator) { login.cancel() }
+            val cancelWatcher = launchCancelWatcher(indicator) { login.cancel() }
 
-            indicator.text = "Obtaining OpenShift access..."
-            val osToken = login.awaitResult(AbstractAuthSessionManager.LOGIN_TIMEOUT_MS)
+            try {
+                indicator.text = "Obtaining OpenShift access..."
+                val osToken = login.awaitResult(AbstractAuthSessionManager.LOGIN_TIMEOUT_MS)
 
-            val finalToken = TokenModel(
-                accessToken = osToken.accessToken,
-                expiresAt = osToken.expiresAt,
-                accountLabel = osToken.accountLabel,
-                kind = AuthTokenKind.TOKEN,
-                clusterApiUrl = selectedCluster.url
-            )
+                val finalToken = TokenModel(
+                    accessToken = osToken.accessToken,
+                    expiresAt = osToken.expiresAt,
+                    accountLabel = osToken.accountLabel,
+                    kind = AuthTokenKind.TOKEN,
+                    clusterApiUrl = selectedCluster.url
+                )
 
-            indicator.text = "Validating cluster access..."
-            val client = createValidatedApiClient(
-                server,
-                certAuthority,
-                finalToken.accessToken,
-                null,
-                null,
-                tlsContext,
-                "Authentication failed: token received from OpenShift Authenticator is invalid or expired."
-            )
+                indicator.text = "Validating cluster access..."
+                val client = createValidatedApiClient(
+                    server,
+                    certAuthority,
+                    finalToken.accessToken,
+                    null,
+                    null,
+                    tlsContext,
+                    "Authentication failed: token received from OpenShift Authenticator is invalid or expired."
+                )
 
-            setTokenDisplay(finalToken.accessToken)
-            saveKubeconfig(selectedCluster, finalToken.accessToken, indicator)
-            devSpacesContext.client = client
+                setTokenDisplay(finalToken.accessToken)
+                saveKubeconfig(selectedCluster, finalToken.accessToken, indicator)
+                devSpacesContext.client = client
+            } finally {
+                cancelWatcher.cancel()
+            }
         }
     }
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -2,6 +2,7 @@
 <idea-plugin>
     <id>com.redhat.devtools.gateway</id>
     <name>OpenShift Dev Spaces</name>
+    <version>${pluginVersion}</version>
     <vendor email="developers@redhat.com" url="https://www.redhat.com">Red-Hat</vendor>
 
     <depends>com.intellij.modules.platform</depends>


### PR DESCRIPTION
This PR fixes several issues that can block JetBrains Gateway when connecting to OpenShift Dev Spaces through OpenShift OAuth, especially when the cluster delegates authentication to an external IdP such as Entra ID.

Changes included:

- Preserve default JVM trust roots when creating TLS contexts with additional trusted certificates.
- Avoid unrelated Red Hat SSO/OIDC initialization in the OpenShift connection wizard.
- Validate OpenShift authentication with `SelfSubjectAccessReview` instead of listing namespaces.
- Cancel the OAuth progress watcher after browser login completes so the coroutine can finish.
- Avoid blocking the connection flow on optional kubeconfig persistence.
- Complete the Gateway connection if the thin client is already present before readiness listeners are attached.

## Problem

When using OpenShift OAuth against an OpenShift cluster backed by an external identity provider, Gateway could get stuck or fail at different points in the connection flow.

Observed symptoms included:

- The connector could fail early due to unrelated Red Hat SSO/OIDC discovery.
- OAuth login could complete successfully, but the UI remained stuck on `Validating cluster access...`.
- TLS validation could fail because custom/empty trust handling replaced the default JVM trust roots.
- Authentication validation used namespace listing, which is heavier than needed and may require broader permissions.
- The UI could remain stuck while saving kubeconfig, even though authentication had already succeeded.
- The remote IDE connection could remain waiting if the thin client readiness event happened before listeners were attached.

## Fix Details

### TLS trust handling

`SslContextFactory.fromTrustedCerts(...)` now keeps the default JVM trust manager and combines it with custom trusted certificates when provided.

This prevents losing standard trusted roots when no custom certificate is configured or when custom certificates are added.

### OpenShift auth validation

Authentication validation now uses:

```kotlin
SelfSubjectAccessReview
instead of:
listNamespace()
This is a smaller and more appropriate API call for checking whether the token is authenticated.
Browser OAuth flow
The OAuth strategy starts a cancel watcher while waiting for browser login. That watcher was launched inside a coroutine scope and was never cancelled, so the scope could remain active even after login and validation succeeded.
The watcher is now cancelled in finally, allowing the OAuth flow to complete.
OpenShift wizard behavior
The OpenShift connection step no longer initializes or offers the Red Hat SSO auth strategy. This avoids unrelated OIDC discovery during the OpenShift OAuth flow.
Kubeconfig persistence
Saving kubeconfig is optional and should not block a successful connection. It now runs in the background and logs failures instead of holding the connection flow.
Remote IDE readiness
The connection provider now handles the case where the thin client is already present before readiness listeners are attached. It also adds a timeout so the progress dialog does not wait indefinitely.
Testing
Tested locally with:
- JetBrains Gateway 2026.1
- OpenShift Dev Spaces plugin built from this branch
- OpenShift OAuth against an OpenShift cluster using Entra ID behind OpenShift OAuth
- Token-based authentication
- Browser-based OpenShift OAuth authentication
Verified:
- Token authentication still works.
- Browser OAuth no longer remains stuck at Validating cluster access....
- The plugin no longer fails due to unrelated Red Hat SSO/OIDC discovery.
- The connection flow proceeds past kubeconfig saving.
- Remote IDE connection no longer waits indefinitely when the thin client is already present.