### PR TITLE
fix: show wizard and insightful error when SSO is unreachable (crw-11958)

### DIFF
--- a/src/main/kotlin/com/redhat/devtools/gateway/auth/code/OAuthDiscovery.kt
+++ b/src/main/kotlin/com/redhat/devtools/gateway/auth/code/OAuthDiscovery.kt
@@ -16,6 +16,7 @@ import com.redhat.devtools.gateway.util.toServerBaseUrl
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
+import kotlinx.coroutines.CancellationException
 import java.net.URI
 import java.net.http.HttpClient
 import javax.net.ssl.SSLContext
@@ -43,19 +44,17 @@ class OAuthDiscovery(
 
     private val discoveryUrl = "$apiServerUrl/.well-known/oauth-authorization-server"
 
-    suspend fun discoverOAuthMetadata(): OAuthMetadata {
+    suspend fun discoverOAuthMetadata(): Result<OAuthMetadata> = runCatching {
         val response = client.sendGetRequest(discoveryUrl)
-        return json.decodeFromString(OAuthMetadata.serializer(), response.body())
+        json.decodeFromString(OAuthMetadata.serializer(), response.body())
+    }.onFailure { e ->
+        if (e is CancellationException) throw e
+        thisLogger().warn("TLS trust: OAuth discovery request to $discoveryUrl failed", e)
     }
 
     suspend fun endpointBaseUrls(): List<String> {
         thisLogger().info("TLS trust: discovering OAuth endpoints from $discoveryUrl")
-        val md = try {
-            discoverOAuthMetadata()
-        } catch (e: Exception) {
-            thisLogger().error("TLS trust: OAuth discovery request to $discoveryUrl failed", e)
-            throw e
-        }
+        val md = discoverOAuthMetadata().getOrThrow()
         val urls = listOf(md.tokenEndpoint, md.authorizationEndpoint)
             .map { URI(it).toServerBaseUrl() }
             .distinct()

--- a/src/main/kotlin/com/redhat/devtools/gateway/auth/code/OpenShiftAuthCodeFlow.kt
+++ b/src/main/kotlin/com/redhat/devtools/gateway/auth/code/OpenShiftAuthCodeFlow.kt
@@ -64,7 +64,7 @@ class OpenShiftAuthCodeFlow(
     }
 
     override suspend fun startAuthFlow(): AuthCodeRequest {
-        metadata = discovery.discoverOAuthMetadata()
+        metadata = discovery.discoverOAuthMetadata().getOrThrow()
         codeVerifier = CodeVerifier()
         state = State()
 
@@ -153,7 +153,7 @@ class OpenShiftAuthCodeFlow(
         val username = parameters["username"] ?: error("Missing 'username'")
         val password = parameters["password"] ?: error("Missing 'password'")
 
-        metadata = discovery.discoverOAuthMetadata()
+        metadata = discovery.discoverOAuthMetadata().getOrThrow()
         codeVerifier = CodeVerifier()
         state = State()
 

--- a/src/main/kotlin/com/redhat/devtools/gateway/auth/oidc/OidcProviderMetadataResolver.kt
+++ b/src/main/kotlin/com/redhat/devtools/gateway/auth/oidc/OidcProviderMetadataResolver.kt
@@ -14,11 +14,20 @@ package com.redhat.devtools.gateway.auth.oidc
 import com.nimbusds.oauth2.sdk.id.Issuer
 import com.nimbusds.openid.connect.sdk.op.OIDCProviderConfigurationRequest
 import com.nimbusds.openid.connect.sdk.op.OIDCProviderMetadata
+import com.redhat.devtools.gateway.DevSpacesBundle
+import com.redhat.devtools.gateway.auth.session.SsoLoginException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import java.net.ConnectException
+import java.net.NoRouteToHostException
+import java.net.SocketTimeoutException
+import java.net.URI
+import java.net.UnknownHostException
+import java.net.http.HttpTimeoutException
+import java.util.concurrent.TimeoutException
 
 class OidcProviderMetadataResolver(
-    authUrl: String
+    private val authUrl: String
 ) {
     private val issuer = Issuer(authUrl)
 
@@ -28,13 +37,52 @@ class OidcProviderMetadataResolver(
     suspend fun resolve(): OIDCProviderMetadata {
         cached?.let { return it }
 
-        val request = OIDCProviderConfigurationRequest(issuer)
-        val httpResponse = withContext(Dispatchers.IO) {
-            request.toHTTPRequest().send()
+        return try {
+            val request = OIDCProviderConfigurationRequest(issuer)
+            val httpResponse = withContext(Dispatchers.IO) {
+                request.toHTTPRequest().send()
+            }
+            val metadata = OIDCProviderMetadata.parse(httpResponse.bodyAsJSONObject)
+            cached = metadata
+            metadata
+        } catch (e: Exception) {
+            when {
+                e is SsoLoginException -> throw e
+                !isSsoUnreachable(e) -> throw e
+                else -> {
+                    val host = ssoProviderHost(authUrl)
+                    throw SsoLoginException.Failed(ssoUnreachableMessage(host)).apply {
+                        initCause(e)
+                    }
+                }
+            }
         }
-        val metadata = OIDCProviderMetadata.parse(httpResponse.bodyAsJSONObject)
-
-        cached = metadata
-        return metadata
     }
+
 }
+
+/**
+ * Returns `true` if [throwable] (or a cause) indicates the SSO provider host could not be reached
+ * (DNS, connection refused, or network/HTTP timeout).
+ */
+internal fun isSsoUnreachable(throwable: Throwable): Boolean =
+    generateSequence(throwable) { it.cause }.any { cause ->
+        cause is UnknownHostException ||
+            cause is ConnectException ||
+            cause is NoRouteToHostException ||
+            cause is HttpTimeoutException ||
+            cause is TimeoutException ||
+            cause is SocketTimeoutException
+    }
+
+internal fun ssoProviderHost(authUrl: String): String =
+    runCatching { URI(authUrl).host }
+        .getOrNull()
+        ?.takeIf { it.isNotBlank() }
+        ?: authUrl
+
+internal fun ssoUnreachableMessage(host: String): String =
+    DevSpacesBundle.message(
+        "connector.wizard_step.openshift_connection.error.sso_unreachable",
+        host
+    )

--- a/src/main/kotlin/com/redhat/devtools/gateway/auth/session/RedHatAuthSessionManager.kt
+++ b/src/main/kotlin/com/redhat/devtools/gateway/auth/session/RedHatAuthSessionManager.kt
@@ -41,9 +41,7 @@ class RedHatAuthSessionManager : AbstractAuthSessionManager() {
 
     private val authConfig = AuthConfig()
 
-    private val providerMetadata = runBlocking {
-        OidcProviderMetadataResolver(authConfig.authUrl).resolve()
-    }
+    private val metadataResolver = OidcProviderMetadataResolver(authConfig.authUrl)
 
     private lateinit var authFlow: RedHatAuthCodeFlow
 
@@ -59,7 +57,7 @@ class RedHatAuthSessionManager : AbstractAuthSessionManager() {
                 authFlow = RedHatAuthCodeFlow(
                     clientId = authConfig.clientId,
                     redirectUri = RedirectUrlBuilder.callbackUrl(serverConfig, port),
-                    providerMetadata = providerMetadata
+                    providerMetadata = metadataResolver.resolve()
                 )
 
                 val request = authFlow.startAuthFlow()

--- a/src/main/resources/messages/DevSpacesBundle.properties
+++ b/src/main/resources/messages/DevSpacesBundle.properties
@@ -25,6 +25,7 @@ connector.wizard_step.openshift_connection.text.openshift_oauth_info=Authenticat
 connector.wizard_step.openshift_connection.text.redhat_sso_info=Authenticate using Red Hat SSO (Sandbox only)
 connector.wizard_step.openshift_connection.text.redhat_sso_token_note=Token will not be saved to kubeconfig
 connector.wizard_step.openshift_connection.text.pipeline_token_comment=Pipeline tokens require special handling
+connector.wizard_step.openshift_connection.error.sso_unreachable=Cannot reach SSO provider ({0}). If you are behind a corporate proxy or firewall, try using Token authentication instead.
 connector.wizard_step.openshift_connection.button.previous=Back
 connector.wizard_step.openshift_connection.button.next=Check connection
 

--- a/src/test/kotlin/com/redhat/devtools/gateway/auth/code/OAuthDiscoveryTest.kt
+++ b/src/test/kotlin/com/redhat/devtools/gateway/auth/code/OAuthDiscoveryTest.kt
@@ -56,7 +56,7 @@ class OAuthDiscoveryTest {
     fun `discoverOAuthMetadata returns metadata when response is valid`() = runTest {
         stubSendAsync(mockHttpResponse(200, metadataJson))
 
-        val metadata = discovery.discoverOAuthMetadata()
+        val metadata = discovery.discoverOAuthMetadata().getOrThrow()
 
         assertThat(metadata.issuer).isEqualTo("https://api.cluster.example.invalid:6443")
         assertThat(metadata.authorizationEndpoint).isEqualTo("https://oauth-openshift.cluster.example.invalid:443/oauth/authorize")
@@ -67,7 +67,7 @@ class OAuthDiscoveryTest {
     fun `discoverOAuthMetadata throws on HTTP error`() = runTest {
         stubSendAsync(mockHttpResponse(404, "Not Found"))
 
-        val result = kotlin.runCatching { discovery.discoverOAuthMetadata() }
+        val result = discovery.discoverOAuthMetadata()
         assertThat(result.isFailure).isTrue
         assertThat(result.exceptionOrNull())
             .isInstanceOf(IllegalStateException::class.java)

--- a/src/test/kotlin/com/redhat/devtools/gateway/auth/code/OpenShiftAuthCodeFlowTest.kt
+++ b/src/test/kotlin/com/redhat/devtools/gateway/auth/code/OpenShiftAuthCodeFlowTest.kt
@@ -38,7 +38,7 @@ class OpenShiftAuthCodeFlowTest {
 
     @Test
     fun `startAuthFlow returns AuthCodeRequest when discovery succeeds`() = runTest {
-        coEvery { discovery.discoverOAuthMetadata() } returns validMetadata
+        coEvery { discovery.discoverOAuthMetadata() } returns Result.success(validMetadata)
 
         val request = authCodeFlow.startAuthFlow()
 
@@ -51,7 +51,7 @@ class OpenShiftAuthCodeFlowTest {
 
     @Test
     fun `startAuthFlow propagates exception when discovery fails`() = runTest {
-        coEvery { discovery.discoverOAuthMetadata() } throws IllegalStateException("Discovery failed")
+        coEvery { discovery.discoverOAuthMetadata() } returns Result.failure(IllegalStateException("Discovery failed"))
 
         val result = kotlin.runCatching { authCodeFlow.startAuthFlow() }
         assertThat(result.isFailure).isTrue
@@ -87,7 +87,7 @@ class OpenShiftAuthCodeFlowTest {
 
     @Test
     fun `login propagates exception when discovery fails`() = runTest {
-        coEvery { discovery.discoverOAuthMetadata() } throws IllegalStateException("Discovery failed")
+        coEvery { discovery.discoverOAuthMetadata() } returns Result.failure(IllegalStateException("Discovery failed"))
 
         val result = kotlin.runCatching {
             authCodeFlow.login(mapOf("username" to "test", "password" to "pass"))

--- a/src/test/kotlin/com/redhat/devtools/gateway/auth/oidc/OidcProviderMetadataResolverTest.kt
+++ b/src/test/kotlin/com/redhat/devtools/gateway/auth/oidc/OidcProviderMetadataResolverTest.kt
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2026 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package com.redhat.devtools.gateway.auth.oidc
+
+import com.redhat.devtools.gateway.auth.session.SsoLoginException
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.io.IOException
+import java.net.ConnectException
+import java.net.NoRouteToHostException
+import java.net.SocketTimeoutException
+import java.net.UnknownHostException
+import java.net.http.HttpTimeoutException
+import java.util.concurrent.TimeoutException
+
+class OidcProviderMetadataResolverTest {
+
+    @Test
+    fun `ssoProviderHost extracts host from auth URL`() {
+        assertThat(ssoProviderHost("https://sso.redhat.com/auth/realms/redhat-external/"))
+            .isEqualTo("sso.redhat.com")
+        assertThat(ssoProviderHost("https://custom.example.com:8443/auth/"))
+            .isEqualTo("custom.example.com")
+    }
+
+    @Test
+    fun `ssoProviderHost falls back to raw URL when host missing`() {
+        assertThat(ssoProviderHost("not-a-url")).isEqualTo("not-a-url")
+    }
+
+    @Test
+    fun `isSsoUnreachable is true for DNS connection and timeout failures`() {
+        assertThat(isSsoUnreachable(UnknownHostException("sso.redhat.com"))).isTrue()
+        assertThat(isSsoUnreachable(ConnectException("Connection refused"))).isTrue()
+        assertThat(isSsoUnreachable(NoRouteToHostException("No route to host"))).isTrue()
+        assertThat(isSsoUnreachable(SocketTimeoutException("Read timed out"))).isTrue()
+        assertThat(isSsoUnreachable(HttpTimeoutException("request timed out"))).isTrue()
+        assertThat(isSsoUnreachable(TimeoutException("timed out"))).isTrue()
+    }
+
+    @Test
+    fun `isSsoUnreachable walks nested causes`() {
+        val nested = IOException("send failed", UnknownHostException("sso.redhat.com"))
+        assertThat(isSsoUnreachable(nested)).isTrue()
+    }
+
+    @Test
+    fun `isSsoUnreachable walks nested causes for NoRouteToHostException`() {
+        val nested = IOException("send failed", NoRouteToHostException("No route to host"))
+        assertThat(isSsoUnreachable(nested)).isTrue()
+    }
+
+    @Test
+    fun `isSsoUnreachable is false for unrelated failures`() {
+        assertThat(isSsoUnreachable(IllegalStateException("bad metadata"))).isFalse()
+        assertThat(isSsoUnreachable(IOException("404 Not Found"))).isFalse()
+    }
+
+    @Test
+    fun `resolve maps unreachable host to SsoLoginException with Token hint`() {
+        val resolver = OidcProviderMetadataResolver(
+            authUrl = "http://localhost:19999/auth/realms/test/"
+        )
+
+        val error = assertThrows<SsoLoginException.Failed> {
+            runBlocking { resolver.resolve() }
+        }
+
+        assertThat(error.message).contains("Cannot reach SSO provider (localhost)")
+        assertThat(error.message).contains("Token authentication")
+        assertThat(error.cause).isNotNull
+        assertThat(isSsoUnreachable(error.cause!!)).isTrue()
+    }
+}


### PR DESCRIPTION
fixes https://redhat.atlassian.net/browse/CRW-11958

with this fix one gets to the Devspaces connection wizard. An error is then displayed once the user tries to connect:
<img width="440" height="217" alt="image" src="https://github.com/user-attachments/assets/e94463a6-e6f8-4b10-b710-d1be80ee9983" />

