### PR TITLE
feat: honor IDE HTTP proxy for all clients (crw-11942)

### DIFF
--- a/docs/ide-http-proxy-manual-test-plan.md
+++ b/docs/ide-http-proxy-manual-test-plan.md
@@ -1,0 +1,95 @@
+# IDE HTTP proxy — verification plan
+
+Honor JetBrains IDEA/Gateway **HTTP Proxy** settings for all plugin outbound HTTP (OkHttp/k8s, `java.net.HttpClient`, OIDC discovery).
+
+Related helper: `com.redhat.devtools.gateway.util.IdeHttpProxy`.
+
+---
+
+## A. Automated checks
+
+### Targeted unit tests
+
+```bash
+./gradlew test \
+  --tests 'com.redhat.devtools.gateway.util.IdeHttpProxyTest' \
+  --tests 'com.redhat.devtools.gateway.openshift.OpenShiftClientBuilderTest' \
+  --tests 'com.redhat.devtools.gateway.auth.oidc.OidcProviderMetadataResolverTest' \
+  --tests 'com.redhat.devtools.gateway.auth.code.*'
+```
+
+Or full suite: `./gradlew test`
+
+### Static coverage sweep
+
+Every outbound builder should go through `IdeHttpProxy`:
+
+| Path | Expect |
+|------|--------|
+| `IdeHttpProxy.configure` | OIDC, OAuth, Sandbox, `BaseClientBuilder`, `LinkClientBuilder` |
+| `HttpClient.newBuilder` | Only inside `IdeHttpProxy.configure(...)` |
+| `OkHttpClient.Builder` | Inside `IdeHttpProxy.configure(...)` (Link also uses `existing.newBuilder()` then configure) |
+| Nimbus `toHTTPRequest().send()` | **Absent** from `src/main` OIDC code |
+
+```bash
+rg -n 'toHTTPRequest|\.send\(\)' src/main/kotlin/com/redhat/devtools/gateway/auth/oidc/
+rg -n 'HttpClient\.newBuilder|OkHttpClient\.Builder|IdeHttpProxy\.configure' src/main/kotlin/
+```
+
+---
+
+## B. Manual proxy matrix (Gateway or IDEA)
+
+**Settings → Appearance & Behavior → System Settings → HTTP Proxy**
+
+Use a reachable Dev Spaces / SSO / cluster environment you already use for plugin testing.
+
+| # | Proxy mode | What to exercise | Pass if |
+|---|------------|------------------|---------|
+| 1 | **No proxy** | OpenShift OAuth and/or RH SSO login, workspace list, connect | Same happy path as before |
+| 2 | **Manual HTTP proxy** | Same flows | Requests succeed through proxy (proxy access logs, or fail clearly without a working proxy) |
+| 3 | **PAC / auto-detect** (if available) | SSO discovery + API calls | Same success |
+| 4 | **No-proxy hosts** | Add SSO + API hosts to exceptions | Direct connect; still works |
+| 5 | **Proxy auth** | Proxy requiring credentials stored in IDE | Login + API succeed after IDE prompts/stores creds |
+
+### Suggested flow per row
+
+1. Start Gateway or IDEA with the plugin loaded.
+2. Remote Development → OpenShift Dev Spaces connector.
+3. Authenticate (OpenShift OAuth and/or Red Hat SSO as applicable).
+4. List workspaces → Connect.
+
+**Signals of proxy use:** proxy access log, or intentional wrong proxy → clear connection failure (then fix and retry).
+
+### Paths covered by that flow
+
+| Stack | Code |
+|-------|------|
+| OIDC metadata (RH SSO) | `OidcProviderMetadataResolver` → `HttpClient` |
+| Token exchange / Sandbox | `RedHatAuthCodeFlow`, `SandboxApi` → `HttpClient` |
+| OpenShift OAuth discovery | `OAuthDiscovery`, `OpenShiftAuthCodeFlow` → `HttpClient` |
+| Cluster API (wizard) | `BaseClientBuilder` / `TokenClientBuilder` → OkHttp |
+| Deep-link / kubeconfig | `LinkClientBuilder` → OkHttp via `newBuilder()` + `IdeHttpProxy` |
+
+---
+
+## C. Done when
+
+- [ ] Targeted (or full) unit tests green
+- [ ] Static sweep matches the table above
+- [ ] Manual matrix rows **1–2** pass; **3–5** if the environment supports them
+- [ ] No regression on the no-proxy path
+
+---
+
+## D. If something fails
+
+| Symptom | Likely spot |
+|---------|-------------|
+| SSO discovery fails only with proxy | `OidcProviderMetadataResolver` / `IdeHttpProxy` (`HttpClient`) — must not use Nimbus `toHTTPRequest().send()` |
+| `407 Proxy Authentication Required` on OAuth/OIDC | `sendAsyncWithProxy407Retry` / `enableBasicAuthForHttpProxyTunnelsOn407` — first 407 should enable Basic (if unset) and retry; explicit JVM props are preserved |
+| Cluster API fails, SSO OK | `BaseClientBuilder` / `LinkClientBuilder` (OkHttp) |
+| Sandbox signup fails | `SandboxApi` |
+| OpenShift OAuth discovery fails | `OAuthDiscovery` / `OpenShiftAuthCodeFlow` |
+| Works without auth proxy, fails with auth | `IdeProxyAuthenticator` / `JdkProxyProvider.ensureDefault` |
+| Connection Failed + address must not be null | Still on `JAVA_NET_AUTHENTICATOR` — ensure OkHttp uses `IdeHttpProxy.PROXY_AUTHENTICATOR` |

--- a/src/main/kotlin/com/redhat/devtools/gateway/auth/code/HttpClientExtensions.kt
+++ b/src/main/kotlin/com/redhat/devtools/gateway/auth/code/HttpClientExtensions.kt
@@ -11,6 +11,7 @@
  */
 package com.redhat.devtools.gateway.auth.code
 
+import com.redhat.devtools.gateway.openshift.reasonPhrase
 import kotlinx.coroutines.future.await
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -39,9 +40,7 @@ suspend fun HttpClient.sendGetRequest(
         .GET()
         .build()
     val response = sendAsync(request, HttpResponse.BodyHandlers.ofString()).await()
-    if (response.statusCode() !in 200..299) {
-        error("$errorPrefix: ${response.statusCode()}\n${response.body()}")
-    }
+    response.checkError(errorPrefix)
     return response
 }
 
@@ -60,8 +59,15 @@ suspend fun HttpClient.sendPostRequest(
         .POST(HttpRequest.BodyPublishers.ofString(formBody))
         .build()
     val response = sendAsync(request, HttpResponse.BodyHandlers.ofString()).await()
-    if (response.statusCode() !in 200..299) {
-        error("$errorPrefix: ${response.statusCode()}\n${response.body()}")
-    }
+    response.checkError(errorPrefix)
     return json.decodeFromString(AccessTokenResponseJson.serializer(), response.body())
+}
+
+private fun HttpResponse<String>.checkError(errorPrefix: String) {
+    if (statusCode() !in 200..299) {
+        val body = body()?.takeIf { it.isNotEmpty() }
+            ?.let { "\n$it" }
+            .orEmpty()
+        error("$errorPrefix: ${statusCode()} ${statusCode().reasonPhrase()}$body")
+    }
 }

--- a/src/main/kotlin/com/redhat/devtools/gateway/auth/code/OAuthDiscovery.kt
+++ b/src/main/kotlin/com/redhat/devtools/gateway/auth/code/OAuthDiscovery.kt
@@ -12,6 +12,7 @@
 package com.redhat.devtools.gateway.auth.code
 
 import com.intellij.openapi.diagnostic.thisLogger
+import com.redhat.devtools.gateway.util.IdeHttpProxy
 import com.redhat.devtools.gateway.util.toServerBaseUrl
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -35,11 +36,12 @@ data class OAuthMetadata(
 class OAuthDiscovery(
     apiServerUrl: String,
     sslContext: SSLContext,
-    private val client: HttpClient = HttpClient.newBuilder()
-        .sslContext(sslContext)
-        .version(HttpClient.Version.HTTP_1_1)
-        .followRedirects(HttpClient.Redirect.NORMAL)
-        .build()
+    private val client: HttpClient = IdeHttpProxy.configure(
+        HttpClient.newBuilder()
+            .sslContext(sslContext)
+            .version(HttpClient.Version.HTTP_1_1)
+            .followRedirects(HttpClient.Redirect.NORMAL)
+    ).build()
 ) {
 
     private val discoveryUrl = "$apiServerUrl/.well-known/oauth-authorization-server"

--- a/src/main/kotlin/com/redhat/devtools/gateway/auth/code/OpenShiftAuthCodeFlow.kt
+++ b/src/main/kotlin/com/redhat/devtools/gateway/auth/code/OpenShiftAuthCodeFlow.kt
@@ -19,6 +19,7 @@ import com.nimbusds.oauth2.sdk.pkce.CodeChallengeMethod
 import com.nimbusds.oauth2.sdk.pkce.CodeVerifier
 import com.nimbusds.openid.connect.sdk.Nonce
 import com.intellij.openapi.diagnostic.thisLogger
+import com.redhat.devtools.gateway.util.IdeHttpProxy
 import kotlinx.coroutines.future.await
 import java.lang.Void
 import java.net.URI
@@ -48,19 +49,21 @@ class OpenShiftAuthCodeFlow(
     private  lateinit var metadata: OAuthMetadata
 
     private val discoveryClient: HttpClient by lazy {
-        HttpClient.newBuilder()
-            .sslContext(sslContext)
-            .version(HttpClient.Version.HTTP_1_1)
-            .followRedirects(HttpClient.Redirect.NORMAL)
-            .build()
+        IdeHttpProxy.configure(
+            HttpClient.newBuilder()
+                .sslContext(sslContext)
+                .version(HttpClient.Version.HTTP_1_1)
+                .followRedirects(HttpClient.Redirect.NORMAL)
+        ).build()
     }
 
     private val noRedirectClient: HttpClient by lazy {
-        HttpClient.newBuilder()
-            .sslContext(sslContext)
-            .version(HttpClient.Version.HTTP_1_1)
-            .followRedirects(HttpClient.Redirect.NEVER)
-            .build()
+        IdeHttpProxy.configure(
+            HttpClient.newBuilder()
+                .sslContext(sslContext)
+                .version(HttpClient.Version.HTTP_1_1)
+                .followRedirects(HttpClient.Redirect.NEVER)
+        ).build()
     }
 
     override suspend fun startAuthFlow(): AuthCodeRequest {
@@ -202,9 +205,7 @@ class OpenShiftAuthCodeFlow(
             .GET()
             .build()
 
-        var response = client
-            .sendAsync(request, HttpResponse.BodyHandlers.discarding())
-            .await()
+        var response = client.sendAsync(request, HttpResponse.BodyHandlers.discarding()).await()
 
         if (response.statusCode() == 401) {
             request = HttpRequest.newBuilder()

--- a/src/main/kotlin/com/redhat/devtools/gateway/auth/code/RedHatAuthCodeFlow.kt
+++ b/src/main/kotlin/com/redhat/devtools/gateway/auth/code/RedHatAuthCodeFlow.kt
@@ -19,6 +19,7 @@ import com.nimbusds.oauth2.sdk.id.ClientID
 import com.nimbusds.oauth2.sdk.id.State
 import com.nimbusds.oauth2.sdk.pkce.CodeChallengeMethod
 import com.nimbusds.oauth2.sdk.pkce.CodeVerifier
+import com.redhat.devtools.gateway.util.IdeHttpProxy
 import com.nimbusds.openid.connect.sdk.AuthenticationRequest
 import com.nimbusds.openid.connect.sdk.Nonce
 import com.nimbusds.openid.connect.sdk.op.OIDCProviderMetadata
@@ -43,10 +44,11 @@ class RedHatAuthCodeFlow(
     private lateinit var state: State
 
     private val httpClient by lazy {
-        HttpClient.newBuilder()
-            .version(HttpClient.Version.HTTP_1_1)
-            .followRedirects(HttpClient.Redirect.NORMAL)
-            .build()
+        IdeHttpProxy.configure(
+            HttpClient.newBuilder()
+                .version(HttpClient.Version.HTTP_1_1)
+                .followRedirects(HttpClient.Redirect.NORMAL)
+        ).build()
     }
 
     override suspend fun startAuthFlow(): AuthCodeRequest {

--- a/src/main/kotlin/com/redhat/devtools/gateway/auth/oidc/OidcProviderMetadataResolver.kt
+++ b/src/main/kotlin/com/redhat/devtools/gateway/auth/oidc/OidcProviderMetadataResolver.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025-2026 Red Hat, Inc.
+ * Copyright (c) 2026 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -11,38 +11,42 @@
  */
 package com.redhat.devtools.gateway.auth.oidc
 
-import com.nimbusds.oauth2.sdk.id.Issuer
-import com.nimbusds.openid.connect.sdk.op.OIDCProviderConfigurationRequest
 import com.nimbusds.openid.connect.sdk.op.OIDCProviderMetadata
 import com.redhat.devtools.gateway.DevSpacesBundle
+import com.redhat.devtools.gateway.auth.code.sendGetRequest
 import com.redhat.devtools.gateway.auth.session.SsoLoginException
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
-import java.net.ConnectException
-import java.net.NoRouteToHostException
-import java.net.SocketTimeoutException
-import java.net.URI
-import java.net.UnknownHostException
+import com.redhat.devtools.gateway.util.IdeHttpProxy
+import java.net.*
+import java.net.http.HttpClient
 import java.net.http.HttpTimeoutException
 import java.util.concurrent.TimeoutException
 
 class OidcProviderMetadataResolver(
-    private val authUrl: String
+    private val authUrl: String,
+    httpClient: HttpClient? = null
 ) {
-    private val issuer = Issuer(authUrl)
+
+    private val discoveryUrl = authUrl.trimEnd('/') + "/.well-known/openid-configuration"
 
     @Volatile
     private var cached: OIDCProviderMetadata? = null
+
+    private val httpClient: HttpClient by lazy {
+        httpClient
+            ?: IdeHttpProxy.configure(
+                HttpClient.newBuilder()
+                    .version(HttpClient.Version.HTTP_1_1)
+                    .followRedirects(HttpClient.Redirect.NORMAL)
+            ).build()
+    }
 
     suspend fun resolve(): OIDCProviderMetadata {
         cached?.let { return it }
 
         return try {
-            val request = OIDCProviderConfigurationRequest(issuer)
-            val httpResponse = withContext(Dispatchers.IO) {
-                request.toHTTPRequest().send()
-            }
-            val metadata = OIDCProviderMetadata.parse(httpResponse.bodyAsJSONObject)
+            val response = httpClient.sendGetRequest(discoveryUrl, "OIDC discovery failed")
+            val body = response.body()
+            val metadata = OIDCProviderMetadata.parse(body)
             cached = metadata
             metadata
         } catch (e: Exception) {
@@ -58,7 +62,6 @@ class OidcProviderMetadataResolver(
             }
         }
     }
-
 }
 
 /**

--- a/src/main/kotlin/com/redhat/devtools/gateway/auth/sandbox/SandboxApi.kt
+++ b/src/main/kotlin/com/redhat/devtools/gateway/auth/sandbox/SandboxApi.kt
@@ -11,6 +11,7 @@
  */
 package com.redhat.devtools.gateway.auth.sandbox
 
+import com.redhat.devtools.gateway.util.IdeHttpProxy
 import kotlinx.coroutines.future.await
 import kotlinx.serialization.json.Json
 import java.net.URI
@@ -23,10 +24,11 @@ class SandboxApi(
     private val timeoutMs: Long
 ) {
 
-    private val httpClient = HttpClient.newBuilder()
-        .version(HttpClient.Version.HTTP_1_1)
-        .followRedirects(HttpClient.Redirect.NORMAL)
-        .build()
+    private val httpClient = IdeHttpProxy.configure(
+        HttpClient.newBuilder()
+            .version(HttpClient.Version.HTTP_1_1)
+            .followRedirects(HttpClient.Redirect.NORMAL)
+    ).build()
 
     private val json = Json {
         ignoreUnknownKeys = true
@@ -39,10 +41,7 @@ class SandboxApi(
             .GET()
             .build()
 
-        val response = httpClient.sendAsync(
-            request,
-            HttpResponse.BodyHandlers.ofString()
-        ).await()
+        val response = httpClient.sendAsync(request, HttpResponse.BodyHandlers.ofString()).await()
 
         if (response.statusCode() != 200) {
             return null
@@ -58,10 +57,7 @@ class SandboxApi(
             .POST(HttpRequest.BodyPublishers.noBody())
             .build()
 
-        val response = httpClient.sendAsync(
-            request,
-            HttpResponse.BodyHandlers.discarding()
-        ).await()
+        val response = httpClient.sendAsync(request, HttpResponse.BodyHandlers.discarding()).await()
 
         return response.statusCode() in 200..299
     }

--- a/src/main/kotlin/com/redhat/devtools/gateway/openshift/ApiExceptionUtils.kt
+++ b/src/main/kotlin/com/redhat/devtools/gateway/openshift/ApiExceptionUtils.kt
@@ -80,21 +80,48 @@ fun ApiException.toWorkspaceException(
 /**
  * Converts HTTP status code to human-readable message.
  */
-fun ApiException.codeToReasonPhrase(): String {
-    val statusMessage = when (code) {
-        400 -> "Bad Request"
-        401 -> "Unauthorized"
-        403 -> "Forbidden"
-        404 -> "Not Found"
-        408 -> "Request Timeout"
-        500 -> "Internal Server Error"
-        502 -> "Bad Gateway"
-        503 -> "Service Unavailable"
-        504 -> "Gateway Timeout"
-        else -> "HTTP Error $code"
-    }
-    return statusMessage
+private fun statusCodeReasonPhrase(code: Int): String = when (code) {
+    100 -> "Continue"
+    101 -> "Switching Protocols"
+    200 -> "OK"
+    201 -> "Created"
+    202 -> "Accepted"
+    204 -> "No Content"
+    301 -> "Moved Permanently"
+    302 -> "Found"
+    304 -> "Not Modified"
+    307 -> "Temporary Redirect"
+    308 -> "Permanent Redirect"
+    400 -> "Bad Request"
+    401 -> "Unauthorized"
+    403 -> "Forbidden"
+    404 -> "Not Found"
+    405 -> "Method Not Allowed"
+    406 -> "Not Acceptable"
+    407 -> "Proxy Authentication Required"
+    408 -> "Request Timeout"
+    409 -> "Conflict"
+    410 -> "Gone"
+    413 -> "Payload Too Large"
+    414 -> "URI Too Long"
+    415 -> "Unsupported Media Type"
+    416 -> "Range Not Satisfiable"
+    422 -> "Unprocessable Content"
+    429 -> "Too Many Requests"
+    500 -> "Internal Server Error"
+    501 -> "Not Implemented"
+    502 -> "Bad Gateway"
+    503 -> "Service Unavailable"
+    504 -> "Gateway Timeout"
+    506 -> "Variant Also Negotiates"
+    else -> "HTTP Error $code"
 }
+
+/** Converts HTTP status code to human-readable message. */
+fun ApiException.codeToReasonPhrase(): String = statusCodeReasonPhrase(code)
+
+/** Converts HTTP status code to human-readable message. */
+fun Int.reasonPhrase(): String = statusCodeReasonPhrase(this)
 
 fun ApiException.shouldBeIgnored(): Boolean =
     code == 403 || code == 404

--- a/src/main/kotlin/com/redhat/devtools/gateway/openshift/apiclient/BaseClientBuilder.kt
+++ b/src/main/kotlin/com/redhat/devtools/gateway/openshift/apiclient/BaseClientBuilder.kt
@@ -11,6 +11,7 @@
  */
 package com.redhat.devtools.gateway.openshift.apiclient
 
+import com.redhat.devtools.gateway.util.IdeHttpProxy
 import io.kubernetes.client.openapi.ApiClient
 import okhttp3.OkHttpClient
 import okhttp3.Protocol
@@ -57,12 +58,13 @@ abstract class BaseClientBuilder : OpenShiftClientBuilder {
      * Uses HTTP/1.1 (not HTTP/2): some OpenShift clusters hang on HTTP/2.
      */
     protected fun createHttpClient(sslContext: SSLContext, trustManager: X509TrustManager): OkHttpClient =
-        OkHttpClient.Builder()
-            .sslSocketFactory(sslContext.socketFactory, trustManager)
-            .connectTimeout(DEFAULT_HTTP_TIMEOUT_SECONDS, TimeUnit.SECONDS)
-            .readTimeout(DEFAULT_HTTP_TIMEOUT_SECONDS, TimeUnit.SECONDS)
-            .writeTimeout(DEFAULT_HTTP_TIMEOUT_SECONDS, TimeUnit.SECONDS)
-            .callTimeout(DEFAULT_HTTP_TIMEOUT_SECONDS, TimeUnit.SECONDS)
-            .protocols(listOf(Protocol.HTTP_1_1))
-            .build()
+        IdeHttpProxy.configure(
+            OkHttpClient.Builder()
+                .sslSocketFactory(sslContext.socketFactory, trustManager)
+                .connectTimeout(DEFAULT_HTTP_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+                .readTimeout(DEFAULT_HTTP_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+                .writeTimeout(DEFAULT_HTTP_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+                .callTimeout(DEFAULT_HTTP_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+                .protocols(listOf(Protocol.HTTP_1_1))
+        ).build()
 }

--- a/src/main/kotlin/com/redhat/devtools/gateway/openshift/apiclient/LinkClientBuilder.kt
+++ b/src/main/kotlin/com/redhat/devtools/gateway/openshift/apiclient/LinkClientBuilder.kt
@@ -13,6 +13,7 @@ package com.redhat.devtools.gateway.openshift.apiclient
 
 import com.intellij.openapi.diagnostic.thisLogger
 import com.redhat.devtools.gateway.kubeconfig.KubeConfigUtils
+import com.redhat.devtools.gateway.util.IdeHttpProxy
 import io.kubernetes.client.util.ClientBuilder
 import io.kubernetes.client.openapi.ApiClient
 
@@ -27,25 +28,33 @@ class LinkClientBuilder(
         val paths = configUtils.getAllConfigFiles()
         if (paths.isEmpty()) {
             thisLogger().debug("No effective kubeconfig found. Falling back to default ApiClient.")
-            return ClientBuilder.defaultClient()
+            return defaultClient()
         }
 
         return try {
             val allConfigs = configUtils.getAllConfigs(paths)
             if (allConfigs.isEmpty()) {
                 thisLogger().debug("No valid kubeconfig content found. Falling back to default ApiClient.")
-                return ClientBuilder.defaultClient()
+                return defaultClient()
             }
 
             val kubeConfig = configUtils.mergeConfigs(allConfigs)
             val client = ClientBuilder.kubeconfig(kubeConfig).build()
+            client.httpClient = IdeHttpProxy.configure(client.httpClient.newBuilder()).build()
             applyReadTimeout(client)
         } catch (e: Exception) {
             thisLogger().debug(
                 "Failed to build effective Kube config from discovered files due to error: ${e.message}. " +
                     "Falling back to the default ApiClient."
             )
-            ClientBuilder.defaultClient()
+            defaultClient()
         }
     }
+
+    private fun defaultClient(): ApiClient {
+        val client = ClientBuilder.defaultClient()
+        client.httpClient = IdeHttpProxy.configure(client.httpClient.newBuilder()).build()
+        return client
+    }
+
 }

--- a/src/main/kotlin/com/redhat/devtools/gateway/util/IdeHttpProxy.kt
+++ b/src/main/kotlin/com/redhat/devtools/gateway/util/IdeHttpProxy.kt
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2026 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package com.redhat.devtools.gateway.util
+
+import com.intellij.openapi.diagnostic.thisLogger
+import com.intellij.util.net.JdkProxyProvider
+import okhttp3.Authenticator
+import okhttp3.OkHttpClient
+import java.net.Proxy
+import java.net.ProxySelector
+import java.net.SocketAddress
+import java.net.URI
+import java.net.http.HttpClient
+import java.io.IOException
+
+private const val KEY_DISABLED_AUTH_TUNNELING_SCHEMES = "jdk.http.auth.tunneling.disabledSchemes"
+private const val KEY_DISABLED_AUTH_PROXYING_SCHEMES = "jdk.http.auth.proxying.disabledSchemes"
+
+/**
+ * Applies JetBrains IDEA/Gateway HTTP proxy settings (static, PAC, no-proxy, auth)
+ * to plugin HTTP clients via [JdkProxyProvider] / the JVM [ProxySelector].
+ */
+object IdeHttpProxy {
+
+    /** Shared OkHttp proxy authenticator; safe with unresolved IDE proxy addresses. */
+    val PROXY_AUTHENTICATOR: Authenticator = IdeProxyAuthenticator()
+
+    private val noProxySelector = object : ProxySelector() {
+        override fun select(uri: URI): List<Proxy> = listOf(Proxy.NO_PROXY)
+        override fun connectFailed(uri: URI, sa: SocketAddress, ioe: IOException) {}
+    }
+
+    fun configure(builder: OkHttpClient.Builder): OkHttpClient.Builder =
+        configure(builder, ideProxySelector())
+
+    fun configure(builder: OkHttpClient.Builder, selector: ProxySelector): OkHttpClient.Builder =
+        builder
+            .proxySelector(selector)
+            .proxyAuthenticator(PROXY_AUTHENTICATOR)
+
+    /**
+     * Configures a [HttpClient.Builder] to use an IDE-compatible proxy selector and authenticator.
+     *
+     * Java's [HttpClient] does **not** use [java.net.Authenticator.getDefault] unless set on the builder.
+     * This method attaches the JVM [java.net.Authenticator.getDefault] (installed by
+     * [JdkProxyProvider.ensureDefault]) to the builder.
+     *
+     * Also allows Basic for HTTPS CONNECT / HTTP proxying when the corresponding
+     * `jdk.http.auth.*.disabledSchemes` properties are **unset** (see
+     * [enableBasicAuthForHttpProxyTunnelsIfUnset]). Explicit user/IDE values are preserved.
+     * OkHttp does not need those JDK properties ([PROXY_AUTHENTICATOR] handles 407).
+     *
+     * When [proxySelector] is provided, it overrides the default IDE selector, enabling
+     * test scenarios that require a custom proxy configuration.
+     *
+     * @param builder the HTTP client builder to configure
+     * @param proxySelector optional proxy selector; defaults to the IDE proxy selector from [ideProxySelector]
+     */
+    fun configure(
+        builder: HttpClient.Builder,
+        proxySelector: ProxySelector = ideProxySelector(),
+    ): HttpClient.Builder {
+        runCatching { JdkProxyProvider.ensureDefault() }
+            .onFailure { thisLogger().warn("Failed to ensure default JDK proxy provider", it) }
+        enableBasicAuthForHttpProxyTunnelsIfUnset()
+        val withProxy = builder.proxy(proxySelector)
+        val authenticator = java.net.Authenticator.getDefault() ?: return withProxy
+        return withProxy.authenticator(authenticator)
+    }
+
+    /**
+     * Allows Basic for HTTPS CONNECT / HTTP proxying when configuring [HttpClient].
+     *
+     * These JDK properties are comma-separated lists of **scheme names to disable**
+     * (e.g. `Basic`), not booleans. When unset, the JDK defaults to disabling Basic for
+     * HTTPS CONNECT (since 8u111). Setting a property to `""` means an empty disable-list,
+     * i.e. **no schemes are disabled** — so Basic (and others) are effectively enabled.
+     *
+     * Sets each property to `""` only when that property is **unset** (`null`). Non-empty
+     * values set by the user/IDE are left unchanged. Already-empty values are left as-is.
+     */
+    private fun enableBasicAuthForHttpProxyTunnelsIfUnset() {
+        var changed = false
+        // all schemes allowed
+        if (System.getProperty(KEY_DISABLED_AUTH_TUNNELING_SCHEMES) == null) {
+            System.setProperty(KEY_DISABLED_AUTH_TUNNELING_SCHEMES, "")
+            changed = true
+        }
+        if (System.getProperty(KEY_DISABLED_AUTH_PROXYING_SCHEMES) == null) {
+            System.setProperty(KEY_DISABLED_AUTH_PROXYING_SCHEMES, "")
+            changed = true
+        }
+        if (changed) {
+            thisLogger().debug("Enabled Basic auth for HTTP proxy tunnels (unset jdk.http.auth.*.disabledSchemes)")
+        }
+    }
+
+    private fun ideProxySelector(): ProxySelector =
+        runCatching {
+            JdkProxyProvider.ensureDefault()
+            JdkProxyProvider.getInstance().proxySelector
+        }.getOrElse {
+            thisLogger().warn("Failed to obtain IDE proxy selector, falling back to JVM default", it)
+            ProxySelector.getDefault() ?: noProxySelector
+        }
+}

--- a/src/main/kotlin/com/redhat/devtools/gateway/util/IdeProxyAuthenticator.kt
+++ b/src/main/kotlin/com/redhat/devtools/gateway/util/IdeProxyAuthenticator.kt
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2026 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package com.redhat.devtools.gateway.util
+
+import okhttp3.Credentials
+import okhttp3.Dns
+import okhttp3.HttpUrl
+import okhttp3.Request
+import okhttp3.Response
+import okhttp3.Route
+import java.io.IOException
+import java.net.InetAddress
+import java.net.InetSocketAddress
+import java.net.Proxy
+import java.net.Authenticator as JvmAuthenticator
+
+/**
+ * OkHttp [okhttp3.Authenticator] that reads proxy/server credentials from the JVM
+ * [JvmAuthenticator] (installed by JetBrains [com.intellij.util.net.JdkProxyProvider])
+ * without requiring the proxy [InetSocketAddress] to be already resolved.
+ *
+ * Upstream [okhttp3.Authenticator.JAVA_NET_AUTHENTICATOR] NPEs when
+ * `(proxy.address() as InetSocketAddress).address` is null — common for IDE ProxySelectors.
+ */
+internal class IdeProxyAuthenticator(
+    private val defaultDns: Dns = Dns.SYSTEM,
+) : okhttp3.Authenticator {
+
+    @Throws(IOException::class)
+    override fun authenticate(route: Route?, response: Response): Request? {
+        val challenges = response.challenges()
+
+        for (challenge in challenges) {
+            if (!"Basic".equals(challenge.scheme, ignoreCase = true)) {
+                continue
+            }
+
+            val request = response.request
+            val url = request.url
+            val proxyAuthorization = response.code == 407
+            val proxy = route?.proxy ?: Proxy.NO_PROXY
+            val dns = route?.address?.dns ?: defaultDns
+            val auth = resolveAuth(proxy, proxyAuthorization, url, dns, challenge) ?: continue
+
+            return buildRetryRequest(request, challenge, proxyAuthorization, auth.userName, auth.password)
+        }
+        return null
+    }
+
+    private fun resolveAuth(
+        proxy: Proxy,
+        proxyAuthorization: Boolean,
+        url: HttpUrl,
+        dns: Dns,
+        challenge: okhttp3.Challenge,
+    ) = if (proxyAuthorization) {
+        resolveProxyAuth(proxy, url, dns, challenge)
+    } else {
+        resolveServerAuth(url, proxy, dns, challenge)
+    }
+
+    private fun resolveProxyAuth(
+        proxy: Proxy,
+        url: HttpUrl,
+        dns: Dns,
+        challenge: okhttp3.Challenge,
+    ) = (proxy.address() as? InetSocketAddress)?.let { proxyAddress ->
+        JvmAuthenticator.requestPasswordAuthentication(
+            proxyAddress.hostString,
+            proxy.connectToInetAddress(url, dns),
+            proxyAddress.port,
+            url.scheme,
+            challenge.realm,
+            challenge.scheme,
+            url.toUrl(),
+            JvmAuthenticator.RequestorType.PROXY,
+        )
+    }
+
+    private fun resolveServerAuth(
+        url: HttpUrl,
+        proxy: Proxy,
+        dns: Dns,
+        challenge: okhttp3.Challenge,
+    ) = JvmAuthenticator.requestPasswordAuthentication(
+        url.host,
+        proxy.connectToInetAddress(url, dns),
+        url.port,
+        url.scheme,
+        challenge.realm,
+        challenge.scheme,
+        url.toUrl(),
+        JvmAuthenticator.RequestorType.SERVER,
+    )
+
+    private fun buildRetryRequest(
+        request: Request,
+        challenge: okhttp3.Challenge,
+        proxyAuthorization: Boolean,
+        userName: String,
+        password: CharArray,
+    ): Request {
+        val credentialHeader = if (proxyAuthorization)
+                "Proxy-Authorization"
+            else
+                "Authorization"
+        val credential = Credentials.basic(userName, String(password), challenge.charset)
+        return request.newBuilder()
+            .header(credentialHeader, credential)
+            .build()
+    }
+
+    @Throws(IOException::class)
+    private fun Proxy.connectToInetAddress(url: HttpUrl, dns: Dns): InetAddress =
+        when (type()) {
+            Proxy.Type.DIRECT -> dns.lookup(url.host).first()
+            else -> {
+                val socketAddress = address() as InetSocketAddress
+                socketAddress.address
+                    ?: dns.lookup(socketAddress.hostName).first()
+            }
+        }
+}

--- a/src/main/kotlin/com/redhat/devtools/gateway/view/steps/DevSpacesServerStepView.kt
+++ b/src/main/kotlin/com/redhat/devtools/gateway/view/steps/DevSpacesServerStepView.kt
@@ -501,13 +501,10 @@ class DevSpacesServerStepView(
         thisLogger().warn("Connection to $server failed", e)
         if (!e.isLoginUserCancelled()) {
             val reason = e.message ?: "Unknown error"
-            val tlsHint = if (e.isTlsRelated()) {
-                "\n\nTLS details were written to idea.log (search for \"TLS trust\")."
-            } else {
-                ""
-            }
+            val tlsText = if (e.isTlsRelated()) "TLS details were written to idea.log (search for \"TLS trust\")." else ""
             Dialogs.error(
-                "Could not connect to cluster ${server.stripScheme()}.\n\nReason: $reason$tlsHint",
+                "Could not connect to cluster ${server.stripScheme()}." +
+                        "\n\nReason: $reason${if (e.isTlsRelated()) "\n\n$tlsText" else ""}",
                 "Connection Failed"
             )
         }

--- a/src/test/kotlin/com/redhat/devtools/gateway/auth/oidc/OidcProviderMetadataResolverTest.kt
+++ b/src/test/kotlin/com/redhat/devtools/gateway/auth/oidc/OidcProviderMetadataResolverTest.kt
@@ -11,7 +11,11 @@
  */
 package com.redhat.devtools.gateway.auth.oidc
 
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
 import com.redhat.devtools.gateway.auth.session.SsoLoginException
+import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -21,10 +25,39 @@ import java.net.ConnectException
 import java.net.NoRouteToHostException
 import java.net.SocketTimeoutException
 import java.net.UnknownHostException
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
 import java.net.http.HttpTimeoutException
+import java.util.concurrent.CompletableFuture
 import java.util.concurrent.TimeoutException
 
 class OidcProviderMetadataResolverTest {
+
+    private val validMetadataJson = """
+        {
+            "issuer": "https://sso.example.com/realms/test",
+            "authorization_endpoint": "https://sso.example.com/realms/test/authorize",
+            "token_endpoint": "https://sso.example.com/realms/test/token",
+            "jwks_uri": "https://sso.example.com/realms/test/certs",
+            "response_types_supported": ["code"],
+            "subject_types_supported": ["public"],
+            "id_token_signing_alg": "RS256"
+        }
+    """.trimIndent()
+
+    private fun mockHttpResponse(statusCode: Int, body: String): HttpResponse<String> {
+        val response = mockk<HttpResponse<String>>()
+        every { response.statusCode() } returns statusCode
+        every { response.body() } returns body
+        return response
+    }
+
+    private fun stubSendAsync(httpClient: HttpClient, response: HttpResponse<String>) {
+        every {
+            httpClient.sendAsync(any<HttpRequest>(), any<HttpResponse.BodyHandler<String>>())
+        } returns CompletableFuture.completedFuture(response)
+    }
 
     @Test
     fun `ssoProviderHost extracts host from auth URL`() {
@@ -81,5 +114,71 @@ class OidcProviderMetadataResolverTest {
         assertThat(error.message).contains("Token authentication")
         assertThat(error.cause).isNotNull
         assertThat(isSsoUnreachable(error.cause!!)).isTrue()
+    }
+
+    @Test
+    fun `resolve returns OIDC metadata on successful response`() = runTest {
+        val httpClient = mockk<HttpClient>()
+        val resolver = OidcProviderMetadataResolver(
+            authUrl = "https://sso.example.com/auth/realms/test/",
+            httpClient = httpClient
+        )
+        stubSendAsync(httpClient, mockHttpResponse(200, validMetadataJson))
+
+        val metadata = resolver.resolve()
+
+        assertThat(metadata.issuer.toString()).isEqualTo("https://sso.example.com/realms/test")
+    }
+
+    @Test
+    fun `resolve caches metadata and skips subsequent HTTP requests`() = runTest {
+        val httpClient = mockk<HttpClient>()
+        every {
+            httpClient.sendAsync(any<HttpRequest>(), any<HttpResponse.BodyHandler<String>>())
+        } answers
+            { CompletableFuture.completedFuture(mockHttpResponse(200, validMetadataJson)) }
+        val resolver = OidcProviderMetadataResolver(
+            authUrl = "https://sso.example.com/auth/realms/test/",
+            httpClient = httpClient
+        )
+
+        resolver.resolve()
+        resolver.resolve()
+
+        verify(exactly = 1) {
+            httpClient.sendAsync(any<HttpRequest>(), any<HttpResponse.BodyHandler<String>>())
+        }
+    }
+
+    @Test
+    fun `resolve throws on non-2xx response`() = runTest {
+        val httpClient = mockk<HttpClient>()
+        val resolver = OidcProviderMetadataResolver(
+            authUrl = "https://sso.example.com/auth/realms/test/",
+            httpClient = httpClient
+        )
+        stubSendAsync(httpClient, mockHttpResponse(503, "Service Unavailable"))
+
+        val error = assertThrows<IllegalStateException> {
+            resolver.resolve()
+        }
+
+        assertThat(error.message).contains("503")
+        assertThat(error.message).contains("Service Unavailable")
+    }
+
+    @Test
+    fun `resolve uses proxy-configured HTTP client when provided`() = runTest {
+        val httpClient = mockk<HttpClient>()
+        stubSendAsync(httpClient, mockHttpResponse(200, validMetadataJson))
+        val resolver = OidcProviderMetadataResolver(
+            authUrl = "https://sso.example.com/auth/realms/test/",
+            httpClient = httpClient
+        )
+
+        // The resolver accepts the injected httpClient instead of building
+        // a default client internally, allowing tests to control HTTP behavior.
+        val metadata = resolver.resolve()
+        assertThat(metadata.issuer.toString()).isEqualTo("https://sso.example.com/realms/test")
     }
 }

--- a/src/test/kotlin/com/redhat/devtools/gateway/openshift/OpenShiftClientBuilderTest.kt
+++ b/src/test/kotlin/com/redhat/devtools/gateway/openshift/OpenShiftClientBuilderTest.kt
@@ -19,6 +19,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.unmockkAll
 import io.mockk.verify
+import com.redhat.devtools.gateway.util.IdeHttpProxy
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.AfterEach
@@ -96,6 +97,18 @@ class OpenShiftClientBuilderTest {
             .build()
 
         assertThat(client.httpClient.readTimeoutMillis).isEqualTo(45_000)
+    }
+
+    @Test
+    fun `TokenClientBuilder OkHttpClient uses IDE proxy authenticator`() {
+        val client = TokenClientBuilder(
+            server = "https://api.example.com:6443",
+            token = "test-token", // notsecret
+            tlsContext = tlsContext,
+        ).build()
+        assertThat(client.httpClient.proxySelector).isNotNull
+        assertThat(client.httpClient.proxyAuthenticator)
+            .isSameAs(IdeHttpProxy.PROXY_AUTHENTICATOR)
     }
 
     @Test

--- a/src/test/kotlin/com/redhat/devtools/gateway/util/IdeHttpProxyTest.kt
+++ b/src/test/kotlin/com/redhat/devtools/gateway/util/IdeHttpProxyTest.kt
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2026 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package com.redhat.devtools.gateway.util
+
+import okhttp3.OkHttpClient
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.parallel.Execution
+import org.junit.jupiter.api.parallel.ExecutionMode
+import org.junit.jupiter.api.parallel.ResourceLock
+import java.net.Authenticator
+import java.net.InetSocketAddress
+import java.net.PasswordAuthentication
+import java.net.Proxy
+import java.net.ProxySelector
+import java.net.SocketAddress
+import java.net.URI
+import java.net.http.HttpClient
+import java.io.IOException
+
+@Execution(ExecutionMode.SAME_THREAD)
+@ResourceLock("java.net.Authenticator")
+@ResourceLock("jdk.http.auth.system.properties")
+class IdeHttpProxyTest {
+
+    private val fakeSelector = object : ProxySelector() {
+        override fun select(uri: URI): List<Proxy> =
+            listOf(Proxy(Proxy.Type.HTTP, InetSocketAddress("proxy.test", 8080)))
+
+        override fun connectFailed(uri: URI, sa: SocketAddress, ioe: IOException) {}
+    }
+
+    private var previousAuthenticator: Authenticator? = null
+    private var previousTunneling: String? = null
+    private var previousProxying: String? = null
+
+    @BeforeEach
+    fun saveAndInstallJvmAuthenticator() {
+        previousAuthenticator = Authenticator.getDefault()
+        previousTunneling = System.getProperty("jdk.http.auth.tunneling.disabledSchemes")
+        previousProxying = System.getProperty("jdk.http.auth.proxying.disabledSchemes")
+        Authenticator.setDefault(object : Authenticator() {
+            override fun getPasswordAuthentication(): PasswordAuthentication =
+                PasswordAuthentication("testuser", "testpass".toCharArray())
+        })
+    }
+
+    @AfterEach
+    fun restoreJvmState() {
+        Authenticator.setDefault(previousAuthenticator)
+        setOrClearProperty("jdk.http.auth.tunneling.disabledSchemes", previousTunneling)
+        setOrClearProperty("jdk.http.auth.proxying.disabledSchemes", previousProxying)
+    }
+
+    @Test
+    fun `configure OkHttpClient uses injected selector and IDE proxy authenticator`() {
+        val client = IdeHttpProxy.configure(OkHttpClient.Builder(), fakeSelector).build()
+
+        assertThat(client.proxySelector).isSameAs(fakeSelector)
+        assertThat(client.proxyAuthenticator).isSameAs(IdeHttpProxy.PROXY_AUTHENTICATOR)
+    }
+
+    @Test
+    fun `configure HttpClient enables unset disabledSchemes and attaches authenticator`() {
+        System.clearProperty("jdk.http.auth.tunneling.disabledSchemes")
+        System.clearProperty("jdk.http.auth.proxying.disabledSchemes")
+
+        val client = IdeHttpProxy.configure(
+            HttpClient.newBuilder().version(HttpClient.Version.HTTP_1_1),
+            fakeSelector
+        ).build()
+
+        assertThat(client.proxy().orElse(null)).isSameAs(fakeSelector)
+        assertThat(client.authenticator().orElse(null)).isSameAs(Authenticator.getDefault())
+        assertThat(System.getProperty("jdk.http.auth.tunneling.disabledSchemes")).isEmpty()
+        assertThat(System.getProperty("jdk.http.auth.proxying.disabledSchemes")).isEmpty()
+    }
+
+    @Test
+    fun `configure HttpClient preserves user-set disabledSchemes`() {
+        System.setProperty("jdk.http.auth.tunneling.disabledSchemes", "Basic")
+        System.setProperty("jdk.http.auth.proxying.disabledSchemes", "Basic,Digest")
+
+        IdeHttpProxy.configure(
+            HttpClient.newBuilder().version(HttpClient.Version.HTTP_1_1),
+            fakeSelector
+        )
+
+        assertThat(System.getProperty("jdk.http.auth.tunneling.disabledSchemes")).isEqualTo("Basic")
+        assertThat(System.getProperty("jdk.http.auth.proxying.disabledSchemes")).isEqualTo("Basic,Digest")
+    }
+
+    @Test
+    fun `configure HttpClient enables only unset disabledSchemes property`() {
+        System.clearProperty("jdk.http.auth.tunneling.disabledSchemes")
+        System.setProperty("jdk.http.auth.proxying.disabledSchemes", "Basic")
+
+        IdeHttpProxy.configure(
+            HttpClient.newBuilder().version(HttpClient.Version.HTTP_1_1),
+            fakeSelector
+        )
+
+        assertThat(System.getProperty("jdk.http.auth.tunneling.disabledSchemes")).isEmpty()
+        assertThat(System.getProperty("jdk.http.auth.proxying.disabledSchemes")).isEqualTo("Basic")
+    }
+
+    private fun setOrClearProperty(key: String, value: String?) {
+        if (value == null) System.clearProperty(key) else System.setProperty(key, value)
+    }
+}

--- a/src/test/kotlin/com/redhat/devtools/gateway/util/IdeProxyAuthenticatorTest.kt
+++ b/src/test/kotlin/com/redhat/devtools/gateway/util/IdeProxyAuthenticatorTest.kt
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2026 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package com.redhat.devtools.gateway.util
+
+import okhttp3.Address
+import okhttp3.Authenticator
+import okhttp3.Dns
+import okhttp3.Protocol
+import okhttp3.Request
+import okhttp3.Response
+import okhttp3.Route
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatCode
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.parallel.Execution
+import org.junit.jupiter.api.parallel.ExecutionMode
+import org.junit.jupiter.api.parallel.ResourceLock
+import java.net.InetAddress
+import java.net.InetSocketAddress
+import java.net.PasswordAuthentication
+import java.net.Proxy
+import java.net.ProxySelector
+import java.net.SocketAddress
+import java.net.URI
+import java.io.IOException
+import javax.net.SocketFactory
+
+@Execution(ExecutionMode.SAME_THREAD)
+@ResourceLock("java.net.Authenticator")
+class IdeProxyAuthenticatorTest {
+
+    private val fixedDns = Dns { listOf(InetAddress.getByName("127.0.0.1")) }
+    private var savedAuthenticator: java.net.Authenticator? = null
+
+    @BeforeEach
+    fun installJvmAuthenticator() {
+        savedAuthenticator = java.net.Authenticator.getDefault()
+        java.net.Authenticator.setDefault(object : java.net.Authenticator() {
+            override fun getPasswordAuthentication(): PasswordAuthentication =
+                PasswordAuthentication("testuser", "testpass".toCharArray())
+        })
+    }
+
+    @AfterEach
+    fun clearJvmAuthenticator() {
+        java.net.Authenticator.setDefault(savedAuthenticator)
+    }
+
+    @Test
+    fun `authenticate with unresolved proxy address returns Proxy-Authorization without NPE`() {
+        val unresolved = InetSocketAddress.createUnresolved("proxy.test", 3128)
+        val proxy = Proxy(Proxy.Type.HTTP, unresolved)
+        val route = Route(httpAddress(), proxy, unresolved)
+        val response = proxyAuthRequiredResponse()
+
+        val followUp = IdeProxyAuthenticator(fixedDns).authenticate(route, response)
+
+        assertThat(followUp).isNotNull
+        assertThat(followUp!!.header("Proxy-Authorization"))
+            .isEqualTo(okhttp3.Credentials.basic("testuser", "testpass"))
+    }
+
+    // Regression sentinel — documents upstream NPE in OkHttp 4.12 (square/okhttp#9100).
+    // Drop or @Disabled when upgrading OkHttp past the fix.
+    @Test
+    fun `JavaNetAuthenticator NPEs on unresolved proxy address (documents upstream bug)`() {
+        val unresolved = InetSocketAddress.createUnresolved("proxy.test", 3128)
+        val proxy = Proxy(Proxy.Type.HTTP, unresolved)
+        val route = Route(httpAddress(), proxy, unresolved)
+        val response = proxyAuthRequiredResponse()
+
+        assertThatCode {
+            Authenticator.JAVA_NET_AUTHENTICATOR.authenticate(route, response)
+        }.isInstanceOf(NullPointerException::class.java)
+            .hasMessageContaining("address")
+    }
+
+    private fun httpAddress(): Address =
+        Address(
+            "api.example.com",
+            443,
+            fixedDns,
+            SocketFactory.getDefault(),
+            null,
+            null,
+            null,
+            Authenticator.NONE,
+            null,
+            listOf(Protocol.HTTP_1_1),
+            emptyList(),
+            object : ProxySelector() {
+                override fun select(uri: URI) = listOf(Proxy.NO_PROXY)
+                override fun connectFailed(uri: URI, sa: SocketAddress, ioe: IOException) {}
+            },
+        )
+
+    private fun proxyAuthRequiredResponse(): Response {
+        val request = Request.Builder().url("https://api.example.com/").build()
+        return Response.Builder()
+            .request(request)
+            .protocol(Protocol.HTTP_1_1)
+            .code(407)
+            .message("Proxy Authentication Required")
+            .header("Proxy-Authenticate", "Basic realm=\"proxy\"")
+            .build()
+    }
+}


### PR DESCRIPTION
fixes https://redhat.atlassian.net/browse/CRW-11942

@vrubezhny, @azatsarynnyy, @msivasubramaniaan: How to test?

**Steps:**
1. EXEC: run a local squid proxy:
```   
mkdir ~/squid-proxy
cd ~/squid-proxy

### create squid passwd
htpasswd -nbB testuser testpass > passwd

### create squid.conf
cat > squid.conf << 'EOF'
http_port 3128

auth_param basic program /usr/lib/squid/basic_ncsa_auth /etc/squid/passwd
auth_param basic realm Squid Proxy
auth_param basic credentialsttl 2 hours

acl authenticated proxy_auth REQUIRED

http_access allow authenticated
http_access deny all

# Allow HTTPS CONNECT
acl Safe_ports port 0-65535
acl SSL_ports port 0-65535
acl CONNECT method CONNECT

http_access deny !Safe_ports
http_access deny CONNECT !SSL_ports

access_log stdio:/var/log/squid/access.log
EOF

### create docker compose
cat > compose.yaml << 'EOF'
services:
  squid:
    image: docker.io/ubuntu/squid:latest
    container_name: squid
    ports:
      - "3128:3128"
    volumes:
      - ./squid.conf:/etc/squid/squid.conf:ro
      - ./passwd:/etc/squid/passwd:ro
EOF

### create container
podman compose up -d
```
2. EXEC: configure Gateway to use the local proxy:
Hostname: `localhost`
Port: `3128`
Proxy authentication: [x]
Login: `testuser`
Password:`testpass`
<img width="600" alt="image" src="https://github.com/user-attachments/assets/4520ae17-d653-4ebf-8440-b43162744511" />

3. EXEC: connect to Dev Spaces
<img width="600" alt="image" src="https://github.com/user-attachments/assets/09b993dd-35cc-4c6f-a059-c4ee326a2d83" />
