### PR TITLE
fix: relax che-editor ID detection to match any path segment (CRW-11960)

### DIFF
--- a/src/main/kotlin/com/redhat/devtools/gateway/devworkspace/DevWorkspaces.kt
+++ b/src/main/kotlin/com/redhat/devtools/gateway/devworkspace/DevWorkspaces.kt
@@ -97,9 +97,8 @@ class DevWorkspaces(private val client: ApiClient) {
 
     fun isIdeaEditorBased(devWorkspace: DevWorkspace, devWorkspaceTemplateMap: Map<String, List<DevWorkspaceTemplate>>): Boolean {
         // Quick editor ID check
-        val segment = devWorkspace.cheEditor.split("/").getOrNull(1)
-        if (segment != null && CHE_EDITOR_ID_REGEX.matches(segment)) {
-             return true
+        if (devWorkspace.cheEditor.split("/").any { CHE_EDITOR_ID_REGEX.matches(it) }) {
+            return true
         }
 
         // DevWorkspace Template check

--- a/src/test/kotlin/com/redhat/devtools/gateway/devworkspace/DevWorkspacesTest.kt
+++ b/src/test/kotlin/com/redhat/devtools/gateway/devworkspace/DevWorkspacesTest.kt
@@ -199,6 +199,42 @@ class DevWorkspacesTest {
             .hasMessageContaining("API error")
     }
 
+    @Test
+    fun `#isIdeaEditorBased returns true for full path editor annotation`() {
+        val dw = createDevWorkspaceWithEditor("eclipse/che-idea-server/latest")
+        assert(devWorkspaces.isIdeaEditorBased(dw, emptyMap()))
+    }
+
+    @Test
+    fun `#isIdeaEditorBased returns true for editor name only`() {
+        val dw = createDevWorkspaceWithEditor("che-idea-server")
+        assert(devWorkspaces.isIdeaEditorBased(dw, emptyMap()))
+    }
+
+    @Test
+    fun `#isIdeaEditorBased returns true for editor name with version`() {
+        val dw = createDevWorkspaceWithEditor("che-idea-server/latest")
+        assert(devWorkspaces.isIdeaEditorBased(dw, emptyMap()))
+    }
+
+    @Test
+    fun `#isIdeaEditorBased returns true for editor name with prefix`() {
+        val dw = createDevWorkspaceWithEditor("eclipse/che-idea-server")
+        assert(devWorkspaces.isIdeaEditorBased(dw, emptyMap()))
+    }
+
+    @Test
+    fun `#isIdeaEditorBased returns false for non-idea editor`() {
+        val dw = createDevWorkspaceWithEditor("eclipse/che-code/latest")
+        assert(!devWorkspaces.isIdeaEditorBased(dw, emptyMap()))
+    }
+
+    @Test
+    fun `#isIdeaEditorBased returns false for unknown editor`() {
+        val dw = createDevWorkspaceWithEditor("unknown")
+        assert(!devWorkspaces.isIdeaEditorBased(dw, emptyMap()))
+    }
+
     // Helper methods
     private fun mockGetDevWorkspace(devWorkspace: Any) {
         every {
@@ -269,6 +305,20 @@ class DevWorkspacesTest {
                 any()
             )
         }
+    }
+
+    private fun createDevWorkspaceWithEditor(cheEditor: String): DevWorkspace {
+        return DevWorkspace(
+            DevWorkspaceObjectMeta(
+                name = "test-workspace",
+                namespace = "test-namespace",
+                uid = "test-uid",
+                annotations = mapOf("che.eclipse.org/che-editor" to cheEditor),
+                labels = emptyMap()
+            ),
+            DevWorkspaceSpec(started = true),
+            DevWorkspaceStatus(phase = "Running")
+        )
     }
 
     private fun createMockDevWorkspace(


### PR DESCRIPTION
Previously the quick editor ID check hardcoded index 1, assuming the che-editor annotation always had the format "prefix/editor-name/version". This failed when the prefix or version segments were absent.

Now all "/"-separated segments are checked against the regex, so values like "che-idea-server", "che-idea-server/latest", or "eclipse/che-idea-server/latest" are all correctly detected.

Fixes: https://redhat.atlassian.net/browse/CRW-11960


Assisted-By: Claude Opus 4.6 <noreply@anthropic.com>