### PR TITLE
fix: wizard UI stops updating when opened as modal dialog (CRW-12139)

### DIFF
--- a/src/main/kotlin/com/redhat/devtools/gateway/devworkspace/DevWorkspaceWatcher.kt
+++ b/src/main/kotlin/com/redhat/devtools/gateway/devworkspace/DevWorkspaceWatcher.kt
@@ -12,6 +12,8 @@
 package com.redhat.devtools.gateway.devworkspace
 
 import com.intellij.openapi.application.EDT
+import com.intellij.openapi.application.ModalityState
+import com.intellij.openapi.application.asContextElement
 import io.kubernetes.client.util.Watch
 import kotlinx.coroutines.*
 
@@ -55,13 +57,13 @@ class DevWorkspaceWatcher(
                     if (!scope.isActive || stopped) break
 
                     val dw = DevWorkspace.from(event.`object`)
-                    withContext(Dispatchers.EDT) {
+                    if (event.type == "ADDED") {
+                        matches = createFilter(namespace)
+                    }
+                    withContext(Dispatchers.EDT + ModalityState.any().asContextElement()) {
                         if (stopped) return@withContext
                         when (event.type) {
-                            "ADDED"    -> {
-                                matches = createFilter(namespace) // Need this to make it read the new templates list
-                                if(matches(dw)) listener.onAdded(dw)
-                            }
+                            "ADDED"    -> if(matches(dw)) listener.onAdded(dw)
                             "MODIFIED" -> if(matches(dw)) listener.onUpdated(dw) else listener.onDeleted(dw)
                             "DELETED"  -> listener.onDeleted(dw)
                         }

--- a/src/main/kotlin/com/redhat/devtools/gateway/view/steps/DevSpacesServerStepView.kt
+++ b/src/main/kotlin/com/redhat/devtools/gateway/view/steps/DevSpacesServerStepView.kt
@@ -12,9 +12,7 @@
 package com.redhat.devtools.gateway.view.steps
 
 import com.intellij.openapi.Disposable
-import com.intellij.openapi.application.ApplicationManager
-import com.intellij.openapi.application.ModalityState
-import com.intellij.openapi.application.PathManager
+import com.intellij.openapi.application.*
 import com.intellij.openapi.components.service
 import com.intellij.openapi.diagnostic.thisLogger
 import com.intellij.openapi.progress.ProcessCanceledException
@@ -22,11 +20,13 @@ import com.intellij.openapi.progress.ProgressIndicator
 import com.intellij.openapi.progress.runBlockingCancellable
 import com.intellij.openapi.ui.MessageDialogBuilder
 import com.intellij.openapi.wm.impl.welcomeScreen.WelcomeScreenUIManager
-import com.redhat.devtools.gateway.auth.tls.browseCertificate
 import com.intellij.ui.components.JBCheckBox
 import com.intellij.ui.components.JBTabbedPane
 import com.intellij.ui.components.JBTextField
-import com.intellij.ui.dsl.builder.*
+import com.intellij.ui.dsl.builder.Align
+import com.intellij.ui.dsl.builder.AlignX
+import com.intellij.ui.dsl.builder.AlignY
+import com.intellij.ui.dsl.builder.panel
 import com.intellij.util.ui.JBFont
 import com.intellij.util.ui.JBUI
 import com.redhat.devtools.gateway.DevSpacesBundle
@@ -40,14 +40,14 @@ import com.redhat.devtools.gateway.kubeconfig.KubeConfigUpdate
 import com.redhat.devtools.gateway.kubeconfig.KubeConfigUtils
 import com.redhat.devtools.gateway.openshift.Cluster
 import com.redhat.devtools.gateway.settings.DevSpacesSettings
+import com.redhat.devtools.gateway.util.isLoginUserCancelled
+import com.redhat.devtools.gateway.util.isTlsRelated
+import com.redhat.devtools.gateway.util.stripScheme
 import com.redhat.devtools.gateway.view.steps.auth.*
 import com.redhat.devtools.gateway.view.ui.Dialogs
 import com.redhat.devtools.gateway.view.ui.FilteringComboBox
 import com.redhat.devtools.gateway.view.ui.PasteClipboardMenu
 import com.redhat.devtools.gateway.view.ui.requestInitialFocus
-import com.redhat.devtools.gateway.util.isLoginUserCancelled
-import com.redhat.devtools.gateway.util.isTlsRelated
-import com.redhat.devtools.gateway.util.stripScheme
 import kotlinx.coroutines.*
 import java.awt.event.ItemEvent
 import java.awt.event.KeyAdapter
@@ -131,7 +131,7 @@ class DevSpacesServerStepView(
         )
 
         val setTokenDisplay: suspend (String) -> Unit = { token ->
-            ApplicationManager.getApplication().invokeLater {
+            invokeLater {
                 tokenStrategy.tfToken.text = token
             }
         }
@@ -406,21 +406,18 @@ class DevSpacesServerStepView(
             val kubeConfigCurrentCluster = withContext(Dispatchers.IO) {
                 KubeConfigUtils.getCurrentClusterName()
             }
-            ApplicationManager.getApplication().invokeLater(
-                {
-                    if (disposed) return@invokeLater
-                    currentContextClusterName = kubeConfigCurrentCluster
-                    val previouslySelected = tfServer.selectedItem as? Cluster?
-                    setClusters(updatedClusters)
-                    setSelectedCluster(
-                        (previouslySelected)?.name ?: kubeConfigCurrentCluster,
-                        updatedClusters
-                    )
-                    setSelectedAuthTab()
-                    enableSaveConfigCheckbox()
-                },
-                ModalityState.stateForComponent(component)
-            )
+            withContext(Dispatchers.EDT + ModalityState.any().asContextElement()) {
+                if (disposed) return@withContext
+                currentContextClusterName = kubeConfigCurrentCluster
+                val previouslySelected = tfServer.selectedItem as? Cluster?
+                setClusters(updatedClusters)
+                setSelectedCluster(
+                    (previouslySelected)?.name ?: kubeConfigCurrentCluster,
+                    updatedClusters
+                )
+                setSelectedAuthTab()
+                enableSaveConfigCheckbox()
+            }
         }
     }
 
@@ -588,7 +585,7 @@ class DevSpacesServerStepView(
             applyKubeconfigTokenUpdate(cluster, token)
         } catch (e: Exception) {
             thisLogger().warn(e.message ?: "Could not save configuration file", e)
-            ApplicationManager.getApplication().invokeLater {
+            invokeLater {
                 Dialogs.error(e.message ?: "Could not save configuration file", "Save Config Failed")
             }
         }
@@ -610,7 +607,7 @@ class DevSpacesServerStepView(
             applyKubeconfigClientCertUpdate(cluster, clientCertPem, clientKeyPem)
         } catch (e: Exception) {
             thisLogger().warn(e.message ?: "Could not save configuration file", e)
-            ApplicationManager.getApplication().invokeLater {
+            invokeLater {
                 Dialogs.error(e.message ?: "Could not save configuration file", "Save Config Failed")
             }
         }

--- a/src/main/kotlin/com/redhat/devtools/gateway/view/steps/DevSpacesWorkspacesStepView.kt
+++ b/src/main/kotlin/com/redhat/devtools/gateway/view/steps/DevSpacesWorkspacesStepView.kt
@@ -13,8 +13,8 @@ package com.redhat.devtools.gateway.view.steps
 
 import com.intellij.icons.AllIcons
 import com.intellij.openapi.Disposable
+import com.intellij.openapi.application.ModalityState
 import com.intellij.openapi.application.invokeLater
-import com.intellij.openapi.application.runInEdt
 import com.intellij.openapi.diagnostic.thisLogger
 import com.intellij.openapi.progress.ProgressManager
 import com.intellij.openapi.util.Disposer
@@ -209,14 +209,17 @@ class DevSpacesWorkspacesStepView(
                 dwListResult.items
             }
 
-        invokeLater {
-            val selectedIndex = listDevWorkspaces.selectedIndex
-            listDWDataModel.apply {
-                clear()
-                addAll(devWorkspaces)
+        invokeLater(
+            ModalityState.any(),
+            {
+                val selectedIndex = listDevWorkspaces.selectedIndex
+                listDWDataModel.apply {
+                    clear()
+                    addAll(devWorkspaces)
+                }
+                listDevWorkspaces.selectedIndex = getValidSelectedIndex(selectedIndex)
             }
-            listDevWorkspaces.selectedIndex = getValidSelectedIndex(selectedIndex)
-        }
+        )
 
         return lastResourceVersions
     }
@@ -233,11 +236,16 @@ class DevSpacesWorkspacesStepView(
     private fun refreshDevWorkspace(namespace: String, name: String) {
         val refreshedDevWorkspace = DevWorkspaces(devSpacesContext.client).get(namespace, name)
 
-        listDWDataModel
-            .indexOf(refreshedDevWorkspace)
-            .also {
-                if (it != -1) listDWDataModel[it] = refreshedDevWorkspace
+        invokeLater(
+            ModalityState.any(),
+            {
+                listDWDataModel
+                    .indexOf(refreshedDevWorkspace)
+                    .also {
+                        if (it != -1) listDWDataModel[it] = refreshedDevWorkspace
+                    }
             }
+        )
     }
 
     private fun startDevWorkspace() {
@@ -401,20 +409,24 @@ class DevSpacesWorkspacesStepView(
     }
 
     private fun enableButtons() {
-        runInEdt {
-            val workspace = getSelectedWorkspace()
+        invokeLater(
+            ModalityState.any(),
+            {
+                val workspace = getSelectedWorkspace()
 
-            startDevWorkspaceButton.isEnabled = isStopped(workspace)
-            stopDevWorkspaceButton.isEnabled = isRunning(workspace)
+                startDevWorkspaceButton.isEnabled = isStopped(workspace)
+                stopDevWorkspaceButton.isEnabled = isRunning(workspace)
 
-            refreshNextButton()
+                refreshNextButton()
 
-            if (isAlreadyConnected(workspace)) {
-                stopDevWorkspaceButton.toolTipText = "This workspace is already connected."
-            } else {
-                stopDevWorkspaceButton.toolTipText = null
+                if (isAlreadyConnected(workspace)) {
+                    stopDevWorkspaceButton.toolTipText = "This workspace is already connected."
+                } else {
+                    stopDevWorkspaceButton.toolTipText = null
+                }
             }
-        }
+
+        )
     }
 
     private fun getSelectedWorkspace(): DevWorkspace? {
@@ -528,24 +540,30 @@ class DevSpacesWorkspacesStepView(
                 }
 
                 override fun onUpdated(dw: DevWorkspace) {
-                    runInEdt {
-                        val idx = indexOfFirst { it.name == dw.name && it.namespace == dw.namespace }
-                        if (idx == -1) {
-                            val index = findInsertIndex(dw)
-                            workspacesDataModel.add(index, dw)
-                        } else {
-                            workspacesDataModel.set(idx, dw)
+                    invokeLater(
+                        ModalityState.any(),
+                        {
+                            val idx = indexOfFirst { it.name == dw.name && it.namespace == dw.namespace }
+                            if (idx == -1) {
+                                val index = findInsertIndex(dw)
+                                workspacesDataModel.add(index, dw)
+                            } else {
+                                workspacesDataModel.set(idx, dw)
+                            }
                         }
-                    }
+                    )
                 }
 
                 override fun onDeleted(dw: DevWorkspace) {
-                    runInEdt {
-                        val idx = indexOfFirst { it.namespace == dw.namespace && it.name == dw.name }
-                        if (idx >= 0) {
-                            workspacesDataModel.remove(idx)
+                    invokeLater(
+                        ModalityState.any(),
+                        {
+                            val idx = indexOfFirst { it.namespace == dw.namespace && it.name == dw.name }
+                            if (idx >= 0) {
+                                workspacesDataModel.remove(idx)
+                            }
                         }
-                    }
+                    )
                 }
 
                 private fun findInsertIndex(dw: DevWorkspace): Int {


### PR DESCRIPTION
The server selection and workspace selection wizard pages use EDT dispatch (invokeLater, runInEdt, withContext(Dispatchers.EDT)) to update UI components — cluster dropdown, DevWorkspace list, button states, and workspace status icons. These calls default to ModalityState.nonModal(), which defers execution until the modal dialog closes. This causes the UI to freeze when the wizard runs as a modal dialog (File -> Remote Development -> Connect to Dev Spaces), while working fine in non-modal mode (Run Plugin task).

Use ModalityState.any() for all EDT dispatch in the wizard steps and the DevWorkspaceWatcher so that UI updates execute regardless of the current modal context.

Fixes: https://redhat.atlassian.net/browse/CRW-12139


Assisted-By: Claude Opus 4.6 <noreply@anthropic.com>