### PR TITLE
fix: prevent github from scanning test secrets

### DIFF
--- a/.github/secret_scanning.yml
+++ b/.github/secret_scanning.yml
@@ -1,0 +1,2 @@
+paths-ignore:
+  - "src/test/resources/tls/*"  # test-tls-certs


### PR DESCRIPTION
prevents github from complaining about secrets in our tests. see [src/test/resources/tls](https://github.com/redhat-developer/devspaces-gateway-plugin/tree/main/src/test/resources/tls)